### PR TITLE
Map endpoints for remaining user forms

### DIFF
--- a/spec/form-api.json
+++ b/spec/form-api.json
@@ -1,0 +1,15978 @@
+[
+  {
+    "formPath": "OpenDental/Forms/FormASAP.cs",
+    "formName": "FormASAP",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appointments/asap",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recalls/asap",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recalls/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}/priority",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/sites",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched-asap/clinics",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched-asap/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/asap-comms/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAbout.cs",
+    "formName": "FormAbout",
+    "endpoints": [
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/{name}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/update-histories/version/{version}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computers/service-info",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submissions/diagnostics",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccountPick.cs",
+    "formName": "FormAccountPick",
+    "endpoints": [
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts/{id}/balance",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/quickbooks/accounts",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccounting.cs",
+    "formName": "FormAccounting",
+    "endpoints": [
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccountingAutoPayEdit.cs",
+    "formName": "FormAccountingAutoPayEdit",
+    "endpoints": [
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/payment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccountingSetup.cs",
+    "formName": "FormAccountingSetup",
+    "endpoints": [
+      {
+        "path": "/api/prefs/AccountingDepositAccounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingDepositAccounts",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingIncomeAccount",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingIncomeAccount",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingCashIncomeAccount",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingCashIncomeAccount",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/payment-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormActivityLog.cs",
+    "formName": "FormActivityLog",
+    "endpoints": [
+      {
+        "path": "/api/eservice-logs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservice-actions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjMulti.cs",
+    "formName": "FormAdjMulti",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/adjustments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/program-properties",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjust.cs",
+    "formName": "FormAdjust",
+    "endpoints": [
+      {
+        "path": "/api/adjustments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/adjustment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjustSelect.cs",
+    "formName": "FormAdjustSelect",
+    "endpoints": [
+      {
+        "path": "/api/adjustments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjustmentPicker.cs",
+    "formName": "FormAdjustmentPicker",
+    "endpoints": [
+      {
+        "path": "/api/adjustments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/adjustment-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPatientList.cs",
+    "formName": "FormAdvertisingPatientList",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPostcardsAccountSetup.cs",
+    "formName": "FormAdvertisingPostcardsAccountSetup",
+    "endpoints": [
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/sso",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPostcardsSend.cs",
+    "formName": "FormAdvertisingPostcardsSend",
+    "endpoints": [
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/sso",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/patient-lists",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPostcardsSetup.cs",
+    "formName": "FormAdvertisingPostcardsSetup",
+    "endpoints": [
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/advertising-postcard-guid",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/advertising-postcard-guid",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAiChatSession.cs",
+    "formName": "FormAiChatSession",
+    "endpoints": [
+      {
+        "path": "/api/ai/assistants",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/end",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAlertCategorySetup.cs",
+    "formName": "FormAlertCategorySetup",
+    "endpoints": [
+      {
+        "path": "/api/alert-categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/alert-categories",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/alert-categories/{id}/links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/alert-categories/{id}/links",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAlerts.cs",
+    "formName": "FormAlerts",
+    "endpoints": [
+      {
+        "path": "/api/alerts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/alerts/{id}/read",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/alerts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllergyDefEdit.cs",
+    "formName": "FormAllergyDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/medications/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllergyEdit.cs",
+    "formName": "FormAllergyEdit",
+    "endpoints": [
+      {
+        "path": "/api/allergy-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/allergies",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/allergies/{allergyId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/allergies/{allergyId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllergySetup.cs",
+    "formName": "FormAllergySetup",
+    "endpoints": [
+      {
+        "path": "/api/allergy-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllocationsSetup.cs",
+    "formName": "FormAllocationsSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/pay-split-unearned-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAmountEdit.cs",
+    "formName": "FormAmountEdit",
+    "endpoints": [
+      {
+        "path": "/api/financial/amounts/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthElevateSecurityPriv.cs",
+    "formName": "FormAnesthElevateSecurityPriv",
+    "endpoints": [
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedDelDose.cs",
+    "formName": "FormAnesthMedDelDose",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications/{medId}/doses/{doseId}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{medId}/doses/{doseId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedSuppliers.cs",
+    "formName": "FormAnesthMedSuppliers",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedSuppliersEdit.cs",
+    "formName": "FormAnesthMedSuppliersEdit",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedsEdit.cs",
+    "formName": "FormAnesthMedsEdit",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/adjustments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthesiaScore.cs",
+    "formName": "FormAnesthesiaScore",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/anesthetic-records/{recordId}/score",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{recordId}/score",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{recordId}/score",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticMedsIntake.cs",
+    "formName": "FormAnestheticMedsIntake",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/quantity",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/intake",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticMedsInventory.cs",
+    "formName": "FormAnestheticMedsInventory",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticMedsWasteQty.cs",
+    "formName": "FormAnestheticMedsWasteQty",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/waste",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticRecord.cs",
+    "formName": "FormAnestheticRecord",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/anesthetic-records",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/medications",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/medications/{medId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/vitals",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/vitals",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptBreak.cs",
+    "formName": "FormApptBreak",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptConflicts.cs",
+    "formName": "FormApptConflicts",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptEdit.cs",
+    "formName": "FormApptEdit",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recalls/{patientId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptEditOld.cs",
+    "formName": "FormApptEditOld",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptFieldDefs.cs",
+    "formName": "FormApptFieldDefs",
+    "endpoints": [
+      {
+        "path": "/api/appt-field-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-field-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-field-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-field-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptPrintSetup.cs",
+    "formName": "FormApptPrintSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptProcs.cs",
+    "formName": "FormApptProcs",
+    "endpoints": [
+      {
+        "path": "/api/procedures",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptReminderRuleAggEdit.cs",
+    "formName": "FormApptReminderRuleAggEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptReminderRuleEdit.cs",
+    "formName": "FormApptReminderRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptRules.cs",
+    "formName": "FormApptRules",
+    "endpoints": [
+      {
+        "path": "/api/appt-rules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-rules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-rules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptSearchAdvanced.cs",
+    "formName": "FormApptSearchAdvanced",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/search",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/schedule-openings",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptTypeEdit.cs",
+    "formName": "FormApptTypeEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptTypes.cs",
+    "formName": "FormApptTypes",
+    "endpoints": [
+      {
+        "path": "/api/appt-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptViewEdit.cs",
+    "formName": "FormApptViewEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptViewEditMobile.cs",
+    "formName": "FormApptViewEditMobile",
+    "endpoints": [
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptViews.cs",
+    "formName": "FormApptViews",
+    "endpoints": [
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptsOther.cs",
+    "formName": "FormApptsOther",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/family",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/appointments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/recalls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormArManager.cs",
+    "formName": "FormArManager",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ar-manager/patient-aging/unsent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patient-aging/sent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patient-aging/excluded",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patients/{id}/placements",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patients/{id}/status",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAsapSetup.cs",
+    "formName": "FormAsapSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAudit.cs",
+    "formName": "FormAudit",
+    "endpoints": [
+      {
+        "path": "/api/security-logs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAuditOrtho.cs",
+    "formName": "FormAuditOrtho",
+    "endpoints": [
+      {
+        "path": "/api/security-logs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoCode.cs",
+    "formName": "FormAutoCode",
+    "endpoints": [
+      {
+        "path": "/api/auto-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-codes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-codes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoCodeEdit.cs",
+    "formName": "FormAutoCodeEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-codes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-codes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items?autoCodeId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoCommExclusionDays.cs",
+    "formName": "FormAutoCommExclusionDays",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/auto-comm-exclude-dates?clinicId={clinicId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-comm-exclude-dates",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-comm-exclude-dates/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDays",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDays",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDaysUseHQ",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDaysUseHQ",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoItemEdit.cs",
+    "formName": "FormAutoItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-code-items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-conds?autoCodeItemId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-conds?autoCodeItemId={id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-conds",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteControlEdit.cs",
+    "formName": "FormAutoNoteControlEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-note-controls",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteControls.cs",
+    "formName": "FormAutoNoteControls",
+    "endpoints": [
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteEdit.cs",
+    "formName": "FormAutoNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs?autoNoteId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteExport.cs",
+    "formName": "FormAutoNoteExport",
+    "endpoints": [
+      {
+        "path": "/api/auto-notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/export",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteResponsePicker.cs",
+    "formName": "FormAutoNoteResponsePicker",
+    "endpoints": [
+      {
+        "path": "/api/auto-notes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNotes.cs",
+    "formName": "FormAutoNotes",
+    "endpoints": [
+      {
+        "path": "/api/auto-notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/user-prefs/{userId}/AutoNoteExpandedCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/user-prefs/{userId}/AutoNoteExpandedCats",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutomation.cs",
+    "formName": "FormAutomation",
+    "endpoints": [
+      {
+        "path": "/api/automations",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automations",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutomationConditionEdit.cs",
+    "formName": "FormAutomationConditionEdit",
+    "endpoints": [
+      {
+        "path": "/api/automation-conditions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automation-conditions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/automation-conditions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/automation-conditions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/billing-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutomationEdit.cs",
+    "formName": "FormAutomationEdit",
+    "endpoints": [
+      {
+        "path": "/api/automations/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}/conditions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}/conditions",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/comm-log-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAvaTax.cs",
+    "formName": "FormAvaTax",
+    "endpoints": [
+      {
+        "path": "/api/programs/AvaTax",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/AvaTax",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=AvaTax",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=AvaTax",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/adj-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/pat-field-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBackup.cs",
+    "formName": "FormBackup",
+    "endpoints": [
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitEdit.cs",
+    "formName": "FormBenefitEdit",
+    "endpoints": [
+      {
+        "path": "/api/benefits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/covcats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitElectHistory.cs",
+    "formName": "FormBenefitElectHistory",
+    "endpoints": [
+      {
+        "path": "/api/etrans/270?planNum={planNum}&subNum={subNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitFrequencies.cs",
+    "formName": "FormBenefitFrequencies",
+    "endpoints": [
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitFrequencyEdit.cs",
+    "formName": "FormBenefitFrequencyEdit",
+    "endpoints": [
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBilling.cs",
+    "formName": "FormBilling",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/email-addresses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/statements",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/statements/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/statements",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBillingDefaults.cs",
+    "formName": "FormBillingDefaults",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ebills",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ebills",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBillingOptions.cs",
+    "formName": "FormBillingOptions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinic-prefs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/billing-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-filing-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/dunnings",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBillingTypeMerge.cs",
+    "formName": "FormBillingTypeMerge",
+    "endpoints": [
+      {
+        "path": "/api/definitions/billing-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/billing-types/{fromId}/merge/{intoId}",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBlockoutCutCopyPaste.cs",
+    "formName": "FormBlockoutCutCopyPaste",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/blockouts",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/blockouts/copy",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBlockoutDuplicatesFix.cs",
+    "formName": "FormBlockoutDuplicatesFix",
+    "endpoints": [
+      {
+        "path": "/api/blockouts/duplicates/count",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/blockouts/duplicates",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBugSubmission.cs",
+    "formName": "FormBugSubmission",
+    "endpoints": [
+      {
+        "path": "/api/bug-submissions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/bugs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bugs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/job-links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/jobs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBugSubmissionHashVitals.cs",
+    "formName": "FormBugSubmissionHashVitals",
+    "endpoints": [
+      {
+        "path": "/api/bug-submission-hashes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bugs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/registration-keys/patients",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBugSubmissions.cs",
+    "formName": "FormBugSubmissions",
+    "endpoints": [
+      {
+        "path": "/api/bug-submissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submissions",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submission-hashes",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/bugs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/jobs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCCDPrint.cs",
+    "formName": "FormCCDPrint",
+    "endpoints": [
+      {
+        "path": "/api/etrans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/{id}/message-text",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insplans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/inssubs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claimprocs?claimId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/procedures",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCDSILabResult.cs",
+    "formName": "FormCDSILabResult",
+    "endpoints": [
+      {
+        "path": "/api/ucums",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/loincs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomeds",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCDSIntervention.cs",
+    "formName": "FormCDSIntervention",
+    "endpoints": [
+      {
+        "path": "/api/cds/interventions?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds/permissions/{userId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/knowledge-requests",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCDSSetup.cs",
+    "formName": "FormCDSSetup",
+    "endpoints": [
+      {
+        "path": "/api/cds/permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds/permissions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/usergroups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCalendar.cs",
+    "formName": "FormCalendar",
+    "endpoints": [
+      {
+        "path": "/api/calendar",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCanadaOutstandingTransactions.cs",
+    "formName": "FormCanadaOutstandingTransactions",
+    "endpoints": [
+      {
+        "path": "/api/carriers?canadianSupportedTypes=RequestForOutstandingTrans_04",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/canadian/outstanding-transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCanadaPaymentReconciliation.cs",
+    "formName": "FormCanadaPaymentReconciliation",
+    "endpoints": [
+      {
+        "path": "/api/carriers?supportsPaymentReconciliation=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences/PracticeDefaultProv",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/canadian/payment-reconciliations",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCanadaSummaryReconciliation.cs",
+    "formName": "FormCanadaSummaryReconciliation",
+    "endpoints": [
+      {
+        "path": "/api/canadian-networks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers?supportsSummaryReconciliation=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/PracticeDefaultProv",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/canadian/summary-reconciliations",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCredit.cs",
+    "formName": "FormCareCredit",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/carecredit/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patfielddefs/carecredit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/patfields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/applications",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/lookups",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/admin",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/reports",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCreditSetup.cs",
+    "formName": "FormCareCreditSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/carecredit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/carecredit",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/carecredit/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/carecredit/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patfielddefs?type=CareCredit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs?category=PaymentTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providerclinics",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCreditTransactions.cs",
+    "formName": "FormCareCreditTransactions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/carecredit/transactions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions/{id}/acknowledge",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions/{id}/refund",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions/{id}/reprocess",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients?ids={ids}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCreditWeb.cs",
+    "formName": "FormCareCreditWeb",
+    "endpoints": [
+      {
+        "path": "/api/carecredit/sessions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCarrierCombine.cs",
+    "formName": "FormCarrierCombine",
+    "endpoints": [
+      {
+        "path": "/api/carriers?ids={ids}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCarrierEdit.cs",
+    "formName": "FormCarrierEdit",
+    "endpoints": [
+      {
+        "path": "/api/defs?category=CarrierGroupNames",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/canadiannetworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}/dependent-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCarriers.cs",
+    "formName": "FormCarriers",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses/default",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/combine",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ItransImportFields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ItransImportFields",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/itrans/carriers/update",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCdsTriggerEdit.cs",
+    "formName": "FormCdsTriggerEdit",
+    "endpoints": [
+      {
+        "path": "/api/preferences/SoftwareName",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users/{id}/cds-permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/diseasedefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd9/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd10/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomeds/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medications/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/rxnorms/{rxCui}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cvxs/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/allergydefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/loincs/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCdsTriggers.cs",
+    "formName": "FormCdsTriggers",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}/cds-permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr-measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertEmployee.cs",
+    "formName": "FormCertEmployee",
+    "endpoints": [
+      {
+        "path": "/api/employees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertificationEdit.cs",
+    "formName": "FormCertificationEdit",
+    "endpoints": [
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/certs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/certs?includeHidden=true",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertificationSetup.cs",
+    "formName": "FormCertificationSetup",
+    "endpoints": [
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs?categoryId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/certs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertifications.cs",
+    "formName": "FormCertifications",
+    "endpoints": [
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs?includeHidden=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees?employeeId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChangeCloudPassword.cs",
+    "formName": "FormChangeCloudPassword",
+    "endpoints": [
+      {
+        "path": "/api/cloud/password",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/CloudPasswordNeedsReset",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChartView.cs",
+    "formName": "FormChartView",
+    "endpoints": [
+      {
+        "path": "/api/chart-views/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}/display-fields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}/display-fields",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}/display-fields",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChartViewDateFilter.cs",
+    "formName": "FormChartViewDateFilter",
+    "endpoints": [
+      {
+        "path": "/api/chart-views/filter",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChooseDatabase.cs",
+    "formName": "FormChooseDatabase",
+    "endpoints": [
+      {
+        "path": "/api/central-connections/computer-names",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/central-connections/databases",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/central-connections/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachHistory.cs",
+    "formName": "FormClaimAttachHistory",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments/{attachId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachPasteDXC.cs",
+    "formName": "FormClaimAttachPasteDXC",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=ImageCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachPasteDXCItem.cs",
+    "formName": "FormClaimAttachPasteDXCItem",
+    "endpoints": [
+      {
+        "path": "/api/claim-attachments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachSnipDXC.cs",
+    "formName": "FormClaimAttachSnipDXC",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=ImageCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachment.cs",
+    "formName": "FormClaimAttachment",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/definitions?category=ImageCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments/{attachId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachmentItemEdit.cs",
+    "formName": "FormClaimAttachmentItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-attachments/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-attachments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimCreate.cs",
+    "formName": "FormClaimCreate",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/family",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/pat-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/inssubs?family={familyId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimCustomTrackingUpdate.cs",
+    "formName": "FormClaimCustomTrackingUpdate",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=ClaimCustomTracking",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimErrorCode",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/trackings",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/trackings/{trackingId}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimEdit.cs",
+    "formName": "FormClaimEdit",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/family",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimCustomTracking",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments/{attachId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimFormEdit.cs",
+    "formName": "FormClaimFormEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items/{itemId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimFormItemEdit.cs",
+    "formName": "FormClaimFormItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-form-items/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimForms.cs",
+    "formName": "FormClaimForms",
+    "endpoints": [
+      {
+        "path": "/api/claim-forms/internal",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimInstEdit.cs",
+    "formName": "FormClaimInstEdit",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimOverpay.cs",
+    "formName": "FormClaimOverpay",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayBatch.cs",
+    "formName": "FormClaimPayBatch",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}/claims",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-pay-splits/outstanding",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayEdit.cs",
+    "formName": "FormClaimPayEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=InsurancePaymentType",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimPaymentGroups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/required-fields?type=InsPayEdit",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayEditOld.cs",
+    "formName": "FormClaimPayEditOld",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/pay-splits",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayList.cs",
+    "formName": "FormClaimPayList",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimPaymentGroups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayPreAuth.cs",
+    "formName": "FormClaimPayPreAuth",
+    "endpoints": [
+      {
+        "path": "/api/procedures?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayTotal.cs",
+    "formName": "FormClaimPayTotal",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimPaymentTracking",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPrint.cs",
+    "formName": "FormClaimPrint",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/procedures?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimProc.cs",
+    "formName": "FormClaimProc",
+    "endpoints": [
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimProcBlueBookLog.cs",
+    "formName": "FormClaimProcBlueBookLog",
+    "endpoints": [
+      {
+        "path": "/api/claim-procs/{id}/bluebook-logs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimReports.cs",
+    "formName": "FormClaimReports",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}/retrieve-reports",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimResend.cs",
+    "formName": "FormClaimResend",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/resend",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimsSend.cs",
+    "formName": "FormClaimsSend",
+    "endpoints": [
+      {
+        "path": "/api/claims/queue",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}/retrieve-reports",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/history",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/definitions?category=ClaimCustomTracking",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClearinghouseEdit.cs",
+    "formName": "FormClearinghouseEdit",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClearinghouses.cs",
+    "formName": "FormClearinghouses",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/prefs/ClaimReportComputerName",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportComputerName",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveInterval",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveInterval",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveTime",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveTime",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceivedByService",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceivedByService",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultDent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultDent",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultMed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultMed",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultEligibility",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultEligibility",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClinicEdit.cs",
+    "formName": "FormClinicEdit",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClinics.cs",
+    "formName": "FormClinics",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClockEventEdit.cs",
+    "formName": "FormClockEventEdit",
+    "endpoints": [
+      {
+        "path": "/api/clock-events/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clock-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clock-events/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clock-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloneAdd.cs",
+    "formName": "FormCloneAdd",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patient-clones",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudManagement.cs",
+    "formName": "FormCloudManagement",
+    "endpoints": [
+      {
+        "path": "/api/cloud/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud/sessions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud/sessions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudSessionLimit.cs",
+    "formName": "FormCloudSessionLimit",
+    "endpoints": [
+      {
+        "path": "/api/cloud/accounts/{id}/session-limit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud/accounts/{id}/session-limit",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudUserEdit.cs",
+    "formName": "FormCloudUserEdit",
+    "endpoints": [
+      {
+        "path": "/api/cloud-users/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud-users",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud-users/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud-users/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudUsers.cs",
+    "formName": "FormCloudUsers",
+    "endpoints": [
+      {
+        "path": "/api/cloud-users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCodeGroupEdit.cs",
+    "formName": "FormCodeGroupEdit",
+    "endpoints": [
+      {
+        "path": "/api/code-groups/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCodeGroups.cs",
+    "formName": "FormCodeGroups",
+    "endpoints": [
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCodeSystemsImport.cs",
+    "formName": "FormCodeSystemsImport",
+    "endpoints": [
+      {
+        "path": "/api/code-systems/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCommPrefPicker.cs",
+    "formName": "FormCommPrefPicker",
+    "endpoints": [
+      {
+        "path": "/api/communication-preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/communication-preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormComputers.cs",
+    "formName": "FormComputers",
+    "endpoints": [
+      {
+        "path": "/api/computers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/computers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/computers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormConfirmList.cs",
+    "formName": "FormConfirmList",
+    "endpoints": [
+      {
+        "path": "/api/appointments/confirm-list",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}/confirmation",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormConfirmationsSetup.cs",
+    "formName": "FormConfirmationsSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences/confirmation",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/confirmation",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormConnectionLost.cs",
+    "formName": "FormConnectionLost",
+    "endpoints": [
+      {
+        "path": "/api/connections/status",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormContactEdit.cs",
+    "formName": "FormContactEdit",
+    "endpoints": [
+      {
+        "path": "/api/contacts/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormContacts.cs",
+    "formName": "FormContacts",
+    "endpoints": [
+      {
+        "path": "/api/contacts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormContinuityOfCareDocument.cs",
+    "formName": "FormContinuityOfCareDocument",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/ccd",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/ccd",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCounties.cs",
+    "formName": "FormCounties",
+    "endpoints": [
+      {
+        "path": "/api/counties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/counties",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/counties/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/counties/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCpts.cs",
+    "formName": "FormCpts",
+    "endpoints": [
+      {
+        "path": "/api/cpts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cpts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cpts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/cpts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditCardEdit.cs",
+    "formName": "FormCreditCardEdit",
+    "endpoints": [
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditCardManage.cs",
+    "formName": "FormCreditCardManage",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/credit-cards",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditRecurringCharges.cs",
+    "formName": "FormCreditRecurringCharges",
+    "endpoints": [
+      {
+        "path": "/api/credit-recurring-charges",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-recurring-charges/run",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditRecurringDateChoose.cs",
+    "formName": "FormCreditRecurringDateChoose",
+    "endpoints": [
+      {
+        "path": "/api/credit-recurring-charges/dates",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCustomerManagement.cs",
+    "formName": "FormCustomerManagement",
+    "endpoints": [
+      {
+        "path": "/api/registration-keys",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCvx.cs",
+    "formName": "FormCvx",
+    "endpoints": [
+      {
+        "path": "/api/cvxs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDashboardWidgetSetup.cs",
+    "formName": "FormDashboardWidgetSetup",
+    "endpoints": [
+      {
+        "path": "/api/user-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/group-permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/group-permissions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDashboardWidgets.cs",
+    "formName": "FormDashboardWidgets",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDatabaseMaintTemp.cs",
+    "formName": "FormDatabaseMaintTemp",
+    "endpoints": [
+      {
+        "path": "/api/database-maintenance/database-names",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/duplicate-claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/duplicate-supplemental-payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/missing-claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/fix-claimproc-duplicates",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/fix-missing-claim-procs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/backup",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDatabaseMaintenance.cs",
+    "formName": "FormDatabaseMaintenance",
+    "endpoints": [
+      {
+        "path": "/api/database-maintenance/methods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/run",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UpdateInProgressOnComputerName",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UpdateInProgressOnComputerName",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/DatabaseMaintenanceSkipCheckTable",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/DatabaseMaintenanceSkipCheckTable",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDatabaseMaintenancePat.cs",
+    "formName": "FormDatabaseMaintenancePat",
+    "endpoints": [
+      {
+        "path": "/api/database-maintenance/patient-methods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/patient-run",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEdit.cs",
+    "formName": "FormDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEditBlockout.cs",
+    "formName": "FormDefEditBlockout",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEditImages.cs",
+    "formName": "FormDefEditImages",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/TaskAttachmentCategory",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/TaskAttachmentCategory",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEditWebSchedApptTypes.cs",
+    "formName": "FormDefEditWebSchedApptTypes",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/appointment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/def-links",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/def-links",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefaultCCProcs.cs",
+    "formName": "FormDefaultCCProcs",
+    "endpoints": [
+      {
+        "path": "/api/preferences/DefaultCCProcs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/DefaultCCProcs",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/default-procs-sync",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefinitionPicker.cs",
+    "formName": "FormDefinitionPicker",
+    "endpoints": [
+      {
+        "path": "/api/definitions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefinitions.cs",
+    "formName": "FormDefinitions",
+    "endpoints": [
+      {
+        "path": "/api/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDentalSchoolSetup.cs",
+    "formName": "FormDentalSchoolSetup",
+    "endpoints": [
+      {
+        "path": "/api/user-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/SecurityGroupForStudents",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/SecurityGroupForInstructors",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/users/dental-schools/update-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDepositEdit.cs",
+    "formName": "FormDepositEdit",
+    "endpoints": [
+      {
+        "path": "/api/deposits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=AutoDeposit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=PaymentTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=InsurancePaymentType",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDeposits.cs",
+    "formName": "FormDeposits",
+    "endpoints": [
+      {
+        "path": "/api/deposits",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences/PracticeBankNumber",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlanEdit.cs",
+    "formName": "FormDiscountPlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=AdjTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}/patients",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}/patients/count",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlanMerge.cs",
+    "formName": "FormDiscountPlanMerge",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{from}/merge/{to}",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlanSubEdit.cs",
+    "formName": "FormDiscountPlanSubEdit",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/commlogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlans.cs",
+    "formName": "FormDiscountPlans",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}/patients/count",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=AdjTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiseaseDefEdit.cs",
+    "formName": "FormDiseaseDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/disease-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiseaseDefs.cs",
+    "formName": "FormDiseaseDefs",
+    "endpoints": [
+      {
+        "path": "/api/disease-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/disease-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDispensary.cs",
+    "formName": "FormDispensary",
+    "endpoints": [
+      {
+        "path": "/api/disp-supplies",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldCategories.cs",
+    "formName": "FormDisplayFieldCategories",
+    "endpoints": [
+      {
+        "path": "/api/display-field-categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/display-field-categories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldEdit.cs",
+    "formName": "FormDisplayFieldEdit",
+    "endpoints": [
+      {
+        "path": "/api/display-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldOrthoEdit.cs",
+    "formName": "FormDisplayFieldOrthoEdit",
+    "endpoints": [
+      {
+        "path": "/api/display-fields/ortho/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFields.cs",
+    "formName": "FormDisplayFields",
+    "endpoints": [
+      {
+        "path": "/api/display-fields",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldsOrthoChart.cs",
+    "formName": "FormDisplayFieldsOrthoChart",
+    "endpoints": [
+      {
+        "path": "/api/display-fields/ortho",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDomainUserPick.cs",
+    "formName": "FormDomainUserPick",
+    "endpoints": [
+      {
+        "path": "/api/domain-users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDoseSpotAssignClinicId.cs",
+    "formName": "FormDoseSpotAssignClinicId",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDoseSpotAssignUserId.cs",
+    "formName": "FormDoseSpotAssignUserId",
+    "endpoints": [
+      {
+        "path": "/api/dosespot/users/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDoseSpotProperyEdit.cs",
+    "formName": "FormDoseSpotProperyEdit",
+    "endpoints": [
+      {
+        "path": "/api/dosespot/properties/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDropboxAuthorize.cs",
+    "formName": "FormDropboxAuthorize",
+    "endpoints": [
+      {
+        "path": "/api/dropbox/authorize",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDrugManufacturerSetup.cs",
+    "formName": "FormDrugManufacturerSetup",
+    "endpoints": [
+      {
+        "path": "/api/drug-manufacturers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDrugUnitSetup.cs",
+    "formName": "FormDrugUnitSetup",
+    "endpoints": [
+      {
+        "path": "/api/drug-units",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDunningEdit.cs",
+    "formName": "FormDunningEdit",
+    "endpoints": [
+      {
+        "path": "/api/dunning-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDunningSetup.cs",
+    "formName": "FormDunningSetup",
+    "endpoints": [
+      {
+        "path": "/api/dunning-messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/dunning-messages",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClinicalWorks.cs",
+    "formName": "FormEClinicalWorks",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardDefs.cs",
+    "formName": "FormEClipboardDefs",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardImageCaptureDefEdit.cs",
+    "formName": "FormEClipboardImageCaptureDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/imagecapturedefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/imagecapturedefs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/imagecapturedefs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardImageCaptureDefs.cs",
+    "formName": "FormEClipboardImageCaptureDefs",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/imagecapturedefs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/imagecapturedefs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardImagePicker.cs",
+    "formName": "FormEClipboardImagePicker",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/images",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardSheetRule.cs",
+    "formName": "FormEClipboardSheetRule",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/sheetrules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/sheetrules/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardSheetRules.cs",
+    "formName": "FormEClipboardSheetRules",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/sheetrules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/sheetrules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/sheetrules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEHR.cs",
+    "formName": "FormEHR",
+    "endpoints": [
+      {
+        "path": "/api/ehr/patients/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERouting.cs",
+    "formName": "FormERouting",
+    "endpoints": [
+      {
+        "path": "/api/eroutings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutings/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERoutingDefEdit.cs",
+    "formName": "FormERoutingDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/eroutingdefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutingdefs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutingdefs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutingdefs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERoutingDefs.cs",
+    "formName": "FormERoutingDefs",
+    "endpoints": [
+      {
+        "path": "/api/eroutingdefs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERoutings.cs",
+    "formName": "FormERoutings",
+    "endpoints": [
+      {
+        "path": "/api/eroutings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutings/{id}/acknowledge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServices2FactorAuthentication.cs",
+    "formName": "FormEServices2FactorAuthentication",
+    "endpoints": [
+      {
+        "path": "/api/eservices/2fa/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/2fa/verify",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesAutoMsging.cs",
+    "formName": "FormEServicesAutoMsging",
+    "endpoints": [
+      {
+        "path": "/api/eservices/automessages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/automessages/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesAutoMsgingAdvanced.cs",
+    "formName": "FormEServicesAutoMsgingAdvanced",
+    "endpoints": [
+      {
+        "path": "/api/eservices/automessages/advanced",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/automessages/advanced",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesAutoMsgingPreferences.cs",
+    "formName": "FormEServicesAutoMsgingPreferences",
+    "endpoints": [
+      {
+        "path": "/api/eservices/automessages/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/automessages/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesEClipboard.cs",
+    "formName": "FormEServicesEClipboard",
+    "endpoints": [
+      {
+        "path": "/api/eservices/eclipboard/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/eclipboard/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesEConnector.cs",
+    "formName": "FormEServicesEConnector",
+    "endpoints": [
+      {
+        "path": "/api/eservices/econnector/status",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/econnector/restart",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMisc.cs",
+    "formName": "FormEServicesMisc",
+    "endpoints": [
+      {
+        "path": "/api/eservices/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMobileAppDeviceManage.cs",
+    "formName": "FormEServicesMobileAppDeviceManage",
+    "endpoints": [
+      {
+        "path": "/api/eservices/mobileapp/devices",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/mobileapp/devices/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMobileSettings.cs",
+    "formName": "FormEServicesMobileSettings",
+    "endpoints": [
+      {
+        "path": "/api/eservices/mobile/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/mobile/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMobileWeb.cs",
+    "formName": "FormEServicesMobileWeb",
+    "endpoints": [
+      {
+        "path": "/api/eservices/mobileweb/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/mobileweb/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesPatientPortal.cs",
+    "formName": "FormEServicesPatientPortal",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesSetup.cs",
+    "formName": "FormEServicesSetup",
+    "endpoints": [
+      {
+        "path": "/api/eservices/setup",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesSignup.cs",
+    "formName": "FormEServicesSignup",
+    "endpoints": [
+      {
+        "path": "/api/eservices/signup",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesTexting.cs",
+    "formName": "FormEServicesTexting",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/eservices/texting/usage",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedAdvanced.cs",
+    "formName": "FormEServicesWebSchedAdvanced",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/eservices/signups?service=WebSched",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched/hostedurls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched/hostedurls/{clinicId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedNotify.cs",
+    "formName": "FormEServicesWebSchedNotify",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedPat.cs",
+    "formName": "FormEServicesWebSchedPat",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/eservices/signups?service=WebSchedNewPatAppt",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ApptConfirmed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=BlockoutTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedRecall.cs",
+    "formName": "FormEServicesWebSchedRecall",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recall-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ApptConfirmed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEcwDiag.cs",
+    "formName": "FormEcwDiag",
+    "endpoints": [
+      {
+        "path": "/api/programs/eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ecw/diagnostics",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEcwDiagAdv.cs",
+    "formName": "FormEcwDiagAdv",
+    "endpoints": [
+      {
+        "path": "/api/programs/eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ecw/diagnostics/query",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEdgeExpressSetup.cs",
+    "formName": "FormEdgeExpressSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/EdgeExpress",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=EdgeExpress",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/definitions?category=PaymentTypes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEdgeExpressTrans.cs",
+    "formName": "FormEdgeExpressTrans",
+    "endpoints": [
+      {
+        "path": "/api/programs/EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/StoreCCtokens",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/edgeexpress/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEditTestModeOverrides.cs",
+    "formName": "FormEditTestModeOverrides",
+    "endpoints": [
+      {
+        "path": "/api/testmode/overrides/{entity}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/testmode/overrides/{entity}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEduResourceEdit.cs",
+    "formName": "FormEduResourceEdit",
+    "endpoints": [
+      {
+        "path": "/api/edu-resources/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/edu-resources",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/edu-resources/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/edu-resources/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/disease-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEduResourceSetup.cs",
+    "formName": "FormEduResourceSetup",
+    "endpoints": [
+      {
+        "path": "/api/edu-resources",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAmendmentEdit.cs",
+    "formName": "FormEhrAmendmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/amendments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAmendments.cs",
+    "formName": "FormEhrAmendments",
+    "endpoints": [
+      {
+        "path": "/api/ehr/amendments?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAptObsEdit.cs",
+    "formName": "FormEhrAptObsEdit",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/loinc",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd9",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd10",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ucum-codes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAptObses.cs",
+    "formName": "FormEhrAptObses",
+    "endpoints": [
+      {
+        "path": "/api/ehr/apt-observations?appointmentId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrCarePlanEdit.cs",
+    "formName": "FormEhrCarePlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/care-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrCarePlans.cs",
+    "formName": "FormEhrCarePlans",
+    "endpoints": [
+      {
+        "path": "/api/ehr/care-plans?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrClinicalSummary.cs",
+    "formName": "FormEhrClinicalSummary",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrEduBrowser.cs",
+    "formName": "FormEhrEduBrowser",
+    "endpoints": [
+      {
+        "path": "/api/ehr/education-resources",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrEduResourcesPat.cs",
+    "formName": "FormEhrEduResourcesPat",
+    "endpoints": [
+      {
+        "path": "/api/education-resources/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events?patientId={id}&type=EducationProvided",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrElectronicCopy.cs",
+    "formName": "FormEhrElectronicCopy",
+    "endpoints": [
+      {
+        "path": "/api/measure-events?patientId={id}&types=ElectronicCopyRequested,ElectronicCopyProvided",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/ccd/electronic-copy?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrEncryption.cs",
+    "formName": "FormEhrEncryption",
+    "endpoints": [
+      {
+        "path": "/api/email/test-encryption",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrExportCCD.cs",
+    "formName": "FormEhrExportCCD",
+    "endpoints": [
+      {
+        "path": "/api/ehr/ccd/summary",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrGrowthCharts.cs",
+    "formName": "FormEhrGrowthCharts",
+    "endpoints": [
+      {
+        "path": "/api/vitalsigns/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrHash.cs",
+    "formName": "FormEhrHash",
+    "endpoints": [
+      {
+        "path": "/api/email/test-hash",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabImageEdit.cs",
+    "formName": "FormEhrLabImageEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/documents",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/{labId}/images",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/{labId}/images",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabNoteEdit.cs",
+    "formName": "FormEhrLabNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-notes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-notes/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabOrderEdit2014.cs",
+    "formName": "FormEhrLabOrderEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/labs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results?labId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabOrderImport.cs",
+    "formName": "FormEhrLabOrderImport",
+    "endpoints": [
+      {
+        "path": "/api/ehr/labs/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabOrders.cs",
+    "formName": "FormEhrLabOrders",
+    "endpoints": [
+      {
+        "path": "/api/ehr/labs?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabPanelEdit.cs",
+    "formName": "FormEhrLabPanelEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-panels/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-panels/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results?panelId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabPanelImport.cs",
+    "formName": "FormEhrLabPanelImport",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-panels/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-panels/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabPanels.cs",
+    "formName": "FormEhrLabPanels",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-panels?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabResultEdit.cs",
+    "formName": "FormEhrLabResultEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabResultEdit2014.cs",
+    "formName": "FormEhrLabResultEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabSpecimenEdit.cs",
+    "formName": "FormEhrLabSpecimenEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-specimens/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-specimens/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMeasureEventEdit.cs",
+    "formName": "FormEhrMeasureEventEdit",
+    "endpoints": [
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMeasureEvents.cs",
+    "formName": "FormEhrMeasureEvents",
+    "endpoints": [
+      {
+        "path": "/api/measure-events?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMedicalOrderLabEdit.cs",
+    "formName": "FormEhrMedicalOrderLabEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-panels?orderId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMedicalOrderRadEdit.cs",
+    "formName": "FormEhrMedicalOrderRadEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMedicalOrders.cs",
+    "formName": "FormEhrMedicalOrders",
+    "endpoints": [
+      {
+        "path": "/api/medical-orders?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrNotPerformed.cs",
+    "formName": "FormEhrNotPerformed",
+    "endpoints": [
+      {
+        "path": "/api/ehr/not-performed?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrNotPerformedEdit.cs",
+    "formName": "FormEhrNotPerformedEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/codes/value-sets/{oid}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatListElementEdit.cs",
+    "formName": "FormEhrPatListElementEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-list-elements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-list-elements",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-list-elements/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-list-elements/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatListResults.cs",
+    "formName": "FormEhrPatListResults",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/query",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientConfidentialPrefEdit.cs",
+    "formName": "FormEhrPatientConfidentialPrefEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientExport.cs",
+    "formName": "FormEhrPatientExport",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientSelectSimple.cs",
+    "formName": "FormEhrPatientSelectSimple",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientSmoking.cs",
+    "formName": "FormEhrPatientSmoking",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProvKeyEditCust.cs",
+    "formName": "FormEhrProvKeyEditCust",
+    "endpoints": [
+      {
+        "path": "/api/ehr/provider-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProvKeysCustomer.cs",
+    "formName": "FormEhrProvKeysCustomer",
+    "endpoints": [
+      {
+        "path": "/api/ehr/provider-keys",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProviderKeyEdit.cs",
+    "formName": "FormEhrProviderKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProviderKeys.cs",
+    "formName": "FormEhrProviderKeys",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasureEdit.cs",
+    "formName": "FormEhrQualityMeasureEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quality-measures/{id}?startDate={dateStart}&endDate={dateEnd}&provId={provId}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasureEdit2014.cs",
+    "formName": "FormEhrQualityMeasureEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quality-measures/{id}?startDate={dateStart}&endDate={dateEnd}&provId={provId}&year=2014",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasures.cs",
+    "formName": "FormEhrQualityMeasures",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/quality-measures?startDate={dateStart}&endDate={dateEnd}&providerId={provId}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasures2014.cs",
+    "formName": "FormEhrQualityMeasures2014",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/quality-measures?startDate={dateStart}&endDate={dateEnd}&providerId={provId}&year=2014",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQuarterlyKeyEdit.cs",
+    "formName": "FormEhrQuarterlyKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQuarterlyKeyEditCust.cs",
+    "formName": "FormEhrQuarterlyKeyEditCust",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quarterly-keys/generate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrReminders.cs",
+    "formName": "FormEhrReminders",
+    "endpoints": [
+      {
+        "path": "/api/reminder-rules?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events?patientId={id}&type=ReminderSent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSettings.cs",
+    "formName": "FormEhrSettings",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd9",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd10",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSetup.cs",
+    "formName": "FormEhrSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSummaryCcdEdit.cs",
+    "formName": "FormEhrSummaryCcdEdit",
+    "endpoints": [
+      {
+        "path": "/api/summary-ccds/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSummaryOfCare.cs",
+    "formName": "FormEhrSummaryOfCare",
+    "endpoints": [
+      {
+        "path": "/api/measure-events?patientId={id}&type=SummaryOfCareProvidedToDr",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/referral-attachments?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrTimeSynch.cs",
+    "formName": "FormEhrTimeSynch",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/server-time",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrVaccinePatEdit.cs",
+    "formName": "FormEhrVaccinePatEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/vaccines?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccines",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccines/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccines/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrVaccines.cs",
+    "formName": "FormEhrVaccines",
+    "endpoints": [
+      {
+        "path": "/api/ehr/vaccine-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccine-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccine-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccine-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormElectIDEdit.cs",
+    "formName": "FormElectIDEdit",
+    "endpoints": [
+      {
+        "path": "/api/elect-ids/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/elect-ids",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/elect-ids/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/elect-ids/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormElectIDs.cs",
+    "formName": "FormElectIDs",
+    "endpoints": [
+      {
+        "path": "/api/elect-ids",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEligibilityResponseDisplay.cs",
+    "formName": "FormEligibilityResponseDisplay",
+    "endpoints": [
+      {
+        "path": "/api/eligibilities/responses/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailAddressEdit.cs",
+    "formName": "FormEmailAddressEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-addresses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailAddresses.cs",
+    "formName": "FormEmailAddresses",
+    "endpoints": [
+      {
+        "path": "/api/email-addresses",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailAutographEdit.cs",
+    "formName": "FormEmailAutographEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-autographs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-autographs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-autographs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-autographs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailCertRegister.cs",
+    "formName": "FormEmailCertRegister",
+    "endpoints": [
+      {
+        "path": "/api/email-certificates/register",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailDigitalSignature.cs",
+    "formName": "FormEmailDigitalSignature",
+    "endpoints": [
+      {
+        "path": "/api/email-certificates/sign",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailEdit.cs",
+    "formName": "FormEmailEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailHostingAddressVerification.cs",
+    "formName": "FormEmailHostingAddressVerification",
+    "endpoints": [
+      {
+        "path": "/api/email-hosting/addresses/verify",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailHostingSignatures.cs",
+    "formName": "FormEmailHostingSignatures",
+    "endpoints": [
+      {
+        "path": "/api/email-hosting/signatures",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-hosting/signatures",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailInbox.cs",
+    "formName": "FormEmailInbox",
+    "endpoints": [
+      {
+        "path": "/api/email-messages/inbox",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailMessageEdit.cs",
+    "formName": "FormEmailMessageEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailTemplateEdit.cs",
+    "formName": "FormEmailTemplateEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-templates",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-templates/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-templates/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmployeeEdit.cs",
+    "formName": "FormEmployeeEdit",
+    "endpoints": [
+      {
+        "path": "/api/employees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employees",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/employees/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/employees/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmployeeSelect.cs",
+    "formName": "FormEmployeeSelect",
+    "endpoints": [
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmployers.cs",
+    "formName": "FormEmployers",
+    "endpoints": [
+      {
+        "path": "/api/employers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/employers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/employers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEncounterEdit.cs",
+    "formName": "FormEncounterEdit",
+    "endpoints": [
+      {
+        "path": "/api/encounters/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/encounters",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/encounters/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/encounters/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEncounterTool.cs",
+    "formName": "FormEncounterTool",
+    "endpoints": [
+      {
+        "path": "/api/encounters?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEncounters.cs",
+    "formName": "FormEncounters",
+    "endpoints": [
+      {
+        "path": "/api/encounters?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEquipment.cs",
+    "formName": "FormEquipment",
+    "endpoints": [
+      {
+        "path": "/api/equipment",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/equipment",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEquipmentEdit.cs",
+    "formName": "FormEquipmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/equipment/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/equipment/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/equipment/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormErx.cs",
+    "formName": "FormErx",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/erx/session",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormErxAccess.cs",
+    "formName": "FormErxAccess",
+    "endpoints": [
+      {
+        "path": "/api/erx/access",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormErxSetup.cs",
+    "formName": "FormErxSetup",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEservicesPaymentPortal.cs",
+    "formName": "FormEservicesPaymentPortal",
+    "endpoints": [
+      {
+        "path": "/api/eservices/payment-portal",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans270EBraw.cs",
+    "formName": "FormEtrans270EBraw",
+    "endpoints": [
+      {
+        "path": "/api/etrans/270/{id}/raw",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans270Edit.cs",
+    "formName": "FormEtrans270Edit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/270/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/270/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/270/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans277Edit.cs",
+    "formName": "FormEtrans277Edit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/277/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans834Import.cs",
+    "formName": "FormEtrans834Import",
+    "endpoints": [
+      {
+        "path": "/api/etrans/834/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans834Preview.cs",
+    "formName": "FormEtrans834Preview",
+    "endpoints": [
+      {
+        "path": "/api/etrans/834/preview",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ClaimEdit.cs",
+    "formName": "FormEtrans835ClaimEdit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/835/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/835/claims/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ClaimPay.cs",
+    "formName": "FormEtrans835ClaimPay",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/claims/{id}/pay",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ClaimSelect.cs",
+    "formName": "FormEtrans835ClaimSelect",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/claims",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835Edit.cs",
+    "formName": "FormEtrans835Edit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835PickEob.cs",
+    "formName": "FormEtrans835PickEob",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/eobs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835PickEra.cs",
+    "formName": "FormEtrans835PickEra",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/eras",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ProcEdit.cs",
+    "formName": "FormEtrans835ProcEdit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/835/procedures/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835s.cs",
+    "formName": "FormEtrans835s",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtransEdit.cs",
+    "formName": "FormEtransEdit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationCriterionDefEdit.cs",
+    "formName": "FormEvaluationCriterionDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/evaluation-criterion-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-criterion-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-criterion-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-criterion-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationDefEdit.cs",
+    "formName": "FormEvaluationDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/evaluation-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationDefs.cs",
+    "formName": "FormEvaluationDefs",
+    "endpoints": [
+      {
+        "path": "/api/evaluation-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationEdit.cs",
+    "formName": "FormEvaluationEdit",
+    "endpoints": [
+      {
+        "path": "/api/evaluations/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationReport.cs",
+    "formName": "FormEvaluationReport",
+    "endpoints": [
+      {
+        "path": "/api/evaluations/report",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluations.cs",
+    "formName": "FormEvaluations",
+    "endpoints": [
+      {
+        "path": "/api/evaluations",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormExamSheets.cs",
+    "formName": "FormExamSheets",
+    "endpoints": [
+      {
+        "path": "/api/exam-sheets",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/exam-sheets",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/exam-sheets/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/exam-sheets/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFHIRAPIKeyEdit.cs",
+    "formName": "FormFHIRAPIKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/fhir/api-keys",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/api-keys",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/api-keys/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFHIRAssignKey.cs",
+    "formName": "FormFHIRAssignKey",
+    "endpoints": [
+      {
+        "path": "/api/fhir/api-keys/assign",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/api-keys/assign",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFHIRSetup.cs",
+    "formName": "FormFHIRSetup",
+    "endpoints": [
+      {
+        "path": "/api/fhir/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFamilyBalancer.cs",
+    "formName": "FormFamilyBalancer",
+    "endpoints": [
+      {
+        "path": "/api/families/{id}/balance",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFamilyHealthEdit.cs",
+    "formName": "FormFamilyHealthEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/family-health/{patientId}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFamilyMemberSelect.cs",
+    "formName": "FormFamilyMemberSelect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeatureRequest.cs",
+    "formName": "FormFeatureRequest",
+    "endpoints": [
+      {
+        "path": "/api/feature-requests",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/feature-requests",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeEdit.cs",
+    "formName": "FormFeeEdit",
+    "endpoints": [
+      {
+        "path": "/api/fees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fees/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/fees/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedGroupEdit.cs",
+    "formName": "FormFeeSchedGroupEdit",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedule-groups/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedule-groups/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedule-groups/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedGroups.cs",
+    "formName": "FormFeeSchedGroups",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedule-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedule-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedPickAuthOntario.cs",
+    "formName": "FormFeeSchedPickAuthOntario",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/ontario",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedPickRemote.cs",
+    "formName": "FormFeeSchedPickRemote",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/remote",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedTools.cs",
+    "formName": "FormFeeSchedTools",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/tools",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeScheds.cs",
+    "formName": "FormFeeScheds",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeesForIns.cs",
+    "formName": "FormFeesForIns",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/insurance",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFieldDefLink.cs",
+    "formName": "FormFieldDefLink",
+    "endpoints": [
+      {
+        "path": "/api/field-def-links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/field-def-links",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/field-def-links/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFilePicker.cs",
+    "formName": "FormFilePicker",
+    "endpoints": [
+      {
+        "path": "/api/files",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFinanceCharges.cs",
+    "formName": "FormFinanceCharges",
+    "endpoints": [
+      {
+        "path": "/api/finance-charges",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/finance-charges",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFormPatEdit.cs",
+    "formName": "FormFormPatEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/forms",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/forms/{formId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/forms/{formId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGlobalSecurity.cs",
+    "formName": "FormGlobalSecurity",
+    "endpoints": [
+      {
+        "path": "/api/security/global",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/security/global",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGradingScaleEdit.cs",
+    "formName": "FormGradingScaleEdit",
+    "endpoints": [
+      {
+        "path": "/api/grading-scales/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/grading-scales/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/grading-scales/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGradingScales.cs",
+    "formName": "FormGradingScales",
+    "endpoints": [
+      {
+        "path": "/api/grading-scales",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/grading-scales",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGraphEmployeeTime.cs",
+    "formName": "FormGraphEmployeeTime",
+    "endpoints": [
+      {
+        "path": "/api/employee-time/graph",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGraphEmployeeView.cs",
+    "formName": "FormGraphEmployeeView",
+    "endpoints": [
+      {
+        "path": "/api/employee-time/view",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGraphics.cs",
+    "formName": "FormGraphics",
+    "endpoints": [
+      {
+        "path": "/api/graphics/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/graphics/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGridSelection.cs",
+    "formName": "FormGridSelection",
+    "endpoints": [
+      {
+        "path": "/api/grid-selection",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGroupPermEdit.cs",
+    "formName": "FormGroupPermEdit",
+    "endpoints": [
+      {
+        "path": "/api/permissions/groups/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/permissions/groups/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGuardianEdit.cs",
+    "formName": "FormGuardianEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/guardians/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/guardians/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefEdit.cs",
+    "formName": "FormHL7DefEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefFieldEdit.cs",
+    "formName": "FormHL7DefFieldEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definition-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-fields/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefMessageEdit.cs",
+    "formName": "FormHL7DefMessageEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definition-messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefSegmentEdit.cs",
+    "formName": "FormHL7DefSegmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definition-segments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-segments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-segments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7Defs.cs",
+    "formName": "FormHL7Defs",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definitions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7MsgEdit.cs",
+    "formName": "FormHL7MsgEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7Msgs.cs",
+    "formName": "FormHL7Msgs",
+    "endpoints": [
+      {
+        "path": "/api/hl7/messages",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHcpcs.cs",
+    "formName": "FormHcpcs",
+    "endpoints": [
+      {
+        "path": "/api/hcpcs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHieSetup.cs",
+    "formName": "FormHieSetup",
+    "endpoints": [
+      {
+        "path": "/api/hie/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hie/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormIcd10s.cs",
+    "formName": "FormIcd10s",
+    "endpoints": [
+      {
+        "path": "/api/icd10",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormIcd9s.cs",
+    "formName": "FormIcd9s",
+    "endpoints": [
+      {
+        "path": "/api/icd9",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageCatMerge.cs",
+    "formName": "FormImageCatMerge",
+    "endpoints": [
+      {
+        "path": "/api/image-categories/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageDrawColor.cs",
+    "formName": "FormImageDrawColor",
+    "endpoints": [
+      {
+        "path": "/api/images/draw-color",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageFloat.cs",
+    "formName": "FormImageFloat",
+    "endpoints": [
+      {
+        "path": "/api/images/float",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagePicker.cs",
+    "formName": "FormImagePicker",
+    "endpoints": [
+      {
+        "path": "/api/images",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagePickerDXC.cs",
+    "formName": "FormImagePickerDXC",
+    "endpoints": [
+      {
+        "path": "/api/images/dxc",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagePickerPatient.cs",
+    "formName": "FormImagePickerPatient",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageSelect.cs",
+    "formName": "FormImageSelect",
+    "endpoints": [
+      {
+        "path": "/api/images/select",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageSelectClaimAttach.cs",
+    "formName": "FormImageSelectClaimAttach",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImages.cs",
+    "formName": "FormImages",
+    "endpoints": [
+      {
+        "path": "/api/images",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/images",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/images/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagingDeviceEdit.cs",
+    "formName": "FormImagingDeviceEdit",
+    "endpoints": [
+      {
+        "path": "/api/imaging-devices/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging-devices/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging-devices/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagingDevices.cs",
+    "formName": "FormImagingDevices",
+    "endpoints": [
+      {
+        "path": "/api/imaging-devices",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging-devices",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagingSetup.cs",
+    "formName": "FormImagingSetup",
+    "endpoints": [
+      {
+        "path": "/api/imaging/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormIncomeTransferManage.cs",
+    "formName": "FormIncomeTransferManage",
+    "endpoints": [
+      {
+        "path": "/api/income-transfers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/income-transfers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/income-transfers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInfobutton.cs",
+    "formName": "FormInfobutton",
+    "endpoints": [
+      {
+        "path": "/api/infobutton",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInnoDb.cs",
+    "formName": "FormInnoDb",
+    "endpoints": [
+      {
+        "path": "/api/database/innodb",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsAdj.cs",
+    "formName": "FormInsAdj",
+    "endpoints": [
+      {
+        "path": "/api/insurance/adjustments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/adjustments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBenefitNotes.cs",
+    "formName": "FormInsBenefitNotes",
+    "endpoints": [
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBenefits.cs",
+    "formName": "FormInsBenefits",
+    "endpoints": [
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBlueBookRuleEdit.cs",
+    "formName": "FormInsBlueBookRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/ins-bluebook-rules/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBlueBookRules.cs",
+    "formName": "FormInsBlueBookRules",
+    "endpoints": [
+      {
+        "path": "/api/ins-bluebook-rules",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsCatEdit.cs",
+    "formName": "FormInsCatEdit",
+    "endpoints": [
+      {
+        "path": "/api/insurance/categories/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/categories/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/categories/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsCatsSetup.cs",
+    "formName": "FormInsCatsSetup",
+    "endpoints": [
+      {
+        "path": "/api/insurance/categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/categories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsEditLogs.cs",
+    "formName": "FormInsEditLogs",
+    "endpoints": [
+      {
+        "path": "/api/insurance/edit-logs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsEditPatLog.cs",
+    "formName": "FormInsEditPatLog",
+    "endpoints": [
+      {
+        "path": "/api/insurance/patient-logs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsFilingCodeEdit.cs",
+    "formName": "FormInsFilingCodeEdit",
+    "endpoints": [
+      {
+        "path": "/api/insurance/filing-codes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/filing-codes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/filing-codes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsFilingCodes.cs",
+    "formName": "FormInsFilingCodes",
+    "endpoints": [
+      {
+        "path": "/api/insurance/filing-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/filing-codes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsHistSetup.cs",
+    "formName": "FormInsHistSetup",
+    "endpoints": [
+      {
+        "path": "/api/insurance/history-settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/history-settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPayFix.cs",
+    "formName": "FormInsPayFix",
+    "endpoints": [
+      {
+        "path": "/api/insurance/payments/fix",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlan.cs",
+    "formName": "FormInsPlan",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlanConvert_7_5_17.cs",
+    "formName": "FormInsPlanConvert_7_5_17",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/convert",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlanSelectFam.cs",
+    "formName": "FormInsPlanSelectFam",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/family",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlanSubstitution.cs",
+    "formName": "FormInsPlanSubstitution",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/substitution",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlans.cs",
+    "formName": "FormInsPlans",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlansMerge.cs",
+    "formName": "FormInsPlansMerge",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlansOverrides.cs",
+    "formName": "FormInsPlansOverrides",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/{id}/overrides",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans/{id}/overrides",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsRemain.cs",
+    "formName": "FormInsRemain",
+    "endpoints": [
+      {
+        "path": "/api/insurance/remaining",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsSpanEdit.cs",
+    "formName": "FormInsSpanEdit",
+    "endpoints": [
+      {
+        "path": "/api/insurance/spans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/spans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/spans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsVerificationList.cs",
+    "formName": "FormInsVerificationList",
+    "endpoints": [
+      {
+        "path": "/api/insurance/verification",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsVerificationSetup.cs",
+    "formName": "FormInsVerificationSetup",
+    "endpoints": [
+      {
+        "path": "/api/insurance/verification/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/verification/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInstallmentPlanEdit.cs",
+    "formName": "FormInstallmentPlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/installment-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/installment-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/installment-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInterventionEdit.cs",
+    "formName": "FormInterventionEdit",
+    "endpoints": [
+      {
+        "path": "/api/interventions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/interventions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/interventions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInterventions.cs",
+    "formName": "FormInterventions",
+    "endpoints": [
+      {
+        "path": "/api/interventions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/interventions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInvoiceItemSelect.cs",
+    "formName": "FormInvoiceItemSelect",
+    "endpoints": [
+      {
+        "path": "/api/invoices/items",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormJournal.cs",
+    "formName": "FormJournal",
+    "endpoints": [
+      {
+        "path": "/api/journal-entries",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormJournalEntryEdit.cs",
+    "formName": "FormJournalEntryEdit",
+    "endpoints": [
+      {
+        "path": "/api/journal-entries/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/journal-entries/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/journal-entries/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabCaseEdit.cs",
+    "formName": "FormLabCaseEdit",
+    "endpoints": [
+      {
+        "path": "/api/lab-cases/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-cases/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/laboratories",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabCaseSelect.cs",
+    "formName": "FormLabCaseSelect",
+    "endpoints": [
+      {
+        "path": "/api/lab-cases",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabCases.cs",
+    "formName": "FormLabCases",
+    "endpoints": [
+      {
+        "path": "/api/lab-cases",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabTurnaroundEdit.cs",
+    "formName": "FormLabTurnaroundEdit",
+    "endpoints": [
+      {
+        "path": "/api/lab-turnarounds/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-turnarounds/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLaboratories.cs",
+    "formName": "FormLaboratories",
+    "endpoints": [
+      {
+        "path": "/api/laboratories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/laboratories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLaboratoryEdit.cs",
+    "formName": "FormLaboratoryEdit",
+    "endpoints": [
+      {
+        "path": "/api/laboratories/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/laboratories/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLanguageAndRegion.cs",
+    "formName": "FormLanguageAndRegion",
+    "endpoints": [
+      {
+        "path": "/api/preferences/language",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/language",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLanguageDefs.cs",
+    "formName": "FormLanguageDefs",
+    "endpoints": [
+      {
+        "path": "/api/languages/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/languages/definitions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLanguagesUsed.cs",
+    "formName": "FormLanguagesUsed",
+    "endpoints": [
+      {
+        "path": "/api/languages",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLateCharges.cs",
+    "formName": "FormLateCharges",
+    "endpoints": [
+      {
+        "path": "/api/late-charges",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetterEdit.cs",
+    "formName": "FormLetterEdit",
+    "endpoints": [
+      {
+        "path": "/api/letters/templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/letters/templates/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetterMergeEdit.cs",
+    "formName": "FormLetterMergeEdit",
+    "endpoints": [
+      {
+        "path": "/api/letters/merges/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/letters/merges/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetterMerges.cs",
+    "formName": "FormLetterMerges",
+    "endpoints": [
+      {
+        "path": "/api/letters/merges",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetters.cs",
+    "formName": "FormLetters",
+    "endpoints": [
+      {
+        "path": "/api/letters",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLicense.cs",
+    "formName": "FormLicense",
+    "endpoints": [
+      {
+        "path": "/api/license",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/license",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLimitedStatementSelect.cs",
+    "formName": "FormLimitedStatementSelect",
+    "endpoints": [
+      {
+        "path": "/api/statements",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLogOn.cs",
+    "formName": "FormLogOn",
+    "endpoints": [
+      {
+        "path": "/api/auth/login",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLoginFailed.cs",
+    "formName": "FormLoginFailed",
+    "endpoints": [
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLoincs.cs",
+    "formName": "FormLoincs",
+    "endpoints": [
+      {
+        "path": "/api/loincs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMapAreaEdit.cs",
+    "formName": "FormMapAreaEdit",
+    "endpoints": [
+      {
+        "path": "/api/map-areas/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/map-areas/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMarkupTableEdit.cs",
+    "formName": "FormMarkupTableEdit",
+    "endpoints": [
+      {
+        "path": "/api/markup-tables/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/markup-tables/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailAnalytics.cs",
+    "formName": "FormMassEmailAnalytics",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/analytics",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailBirthdays.cs",
+    "formName": "FormMassEmailBirthdays",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/birthdays",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailExamples.cs",
+    "formName": "FormMassEmailExamples",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/examples",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailSend.cs",
+    "formName": "FormMassEmailSend",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/send",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailSendResults.cs",
+    "formName": "FormMassEmailSendResults",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailSetup.cs",
+    "formName": "FormMassEmailSetup",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mass-email/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailTemplate.cs",
+    "formName": "FormMassEmailTemplate",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mass-email/templates/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailTemplates.cs",
+    "formName": "FormMassEmailTemplates",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/templates",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mass-email/templates",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabEdit.cs",
+    "formName": "FormMedLabEdit",
+    "endpoints": [
+      {
+        "path": "/api/med-labs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/med-labs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabHL7MsgText.cs",
+    "formName": "FormMedLabHL7MsgText",
+    "endpoints": [
+      {
+        "path": "/api/med-labs/{id}/hl7",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabPatSelect.cs",
+    "formName": "FormMedLabPatSelect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabResultHist.cs",
+    "formName": "FormMedLabResultHist",
+    "endpoints": [
+      {
+        "path": "/api/med-labs/{id}/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabs.cs",
+    "formName": "FormMedLabs",
+    "endpoints": [
+      {
+        "path": "/api/med-labs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedPat.cs",
+    "formName": "FormMedPat",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedical.cs",
+    "formName": "FormMedical",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/medical",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/medical",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedicationEdit.cs",
+    "formName": "FormMedicationEdit",
+    "endpoints": [
+      {
+        "path": "/api/medications/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medications/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedicationMerge.cs",
+    "formName": "FormMedicationMerge",
+    "endpoints": [
+      {
+        "path": "/api/medications/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedicationReconcile.cs",
+    "formName": "FormMedicationReconcile",
+    "endpoints": [
+      {
+        "path": "/api/medications/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedications.cs",
+    "formName": "FormMedications",
+    "endpoints": [
+      {
+        "path": "/api/medications",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessageReplacementTextEdit.cs",
+    "formName": "FormMessageReplacementTextEdit",
+    "endpoints": [
+      {
+        "path": "/api/messages/replacements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messages/replacements/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessageToPayEdit.cs",
+    "formName": "FormMessageToPayEdit",
+    "endpoints": [
+      {
+        "path": "/api/messages/pay/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messages/pay/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessagingButSetup.cs",
+    "formName": "FormMessagingButSetup",
+    "endpoints": [
+      {
+        "path": "/api/messaging/buttons",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messaging/buttons",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessagingSetup.cs",
+    "formName": "FormMessagingSetup",
+    "endpoints": [
+      {
+        "path": "/api/messaging/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messaging/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMobileBrandingProfileEdit.cs",
+    "formName": "FormMobileBrandingProfileEdit",
+    "endpoints": [
+      {
+        "path": "/api/mobile/branding/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mobile/branding/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMobileCode.cs",
+    "formName": "FormMobileCode",
+    "endpoints": [
+      {
+        "path": "/api/mobile/code",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountDefEdit.cs",
+    "formName": "FormMountDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/radiology/mount-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountDefGenerate.cs",
+    "formName": "FormMountDefGenerate",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-defs/generate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountDefs.cs",
+    "formName": "FormMountDefs",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountItemDefEdit.cs",
+    "formName": "FormMountItemDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-items/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/radiology/mount-items/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountainside.cs",
+    "formName": "FormMountainside",
+    "endpoints": [
+      {
+        "path": "/api/mountainside",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMultiVisitGroup.cs",
+    "formName": "FormMultiVisitGroup",
+    "endpoints": [
+      {
+        "path": "/api/multi-visit-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/multi-visit-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormNewCropBilling.cs",
+    "formName": "FormNewCropBilling",
+    "endpoints": [
+      {
+        "path": "/api/newcrop/billing",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/newcrop/billing",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormNotePick.cs",
+    "formName": "FormNotePick",
+    "endpoints": [
+      {
+        "path": "/api/notes/templates",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormODTouchSecurityEdit.cs",
+    "formName": "FormODTouchSecurityEdit",
+    "endpoints": [
+      {
+        "path": "/api/odtouch/security",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/odtouch/security",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOIDRegistryInternal.cs",
+    "formName": "FormOIDRegistryInternal",
+    "endpoints": [
+      {
+        "path": "/api/oid-registry",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOnlinePayments.cs",
+    "formName": "FormOnlinePayments",
+    "endpoints": [
+      {
+        "path": "/api/online-payments",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOperatories.cs",
+    "formName": "FormOperatories",
+    "endpoints": [
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOperatoryEdit.cs",
+    "formName": "FormOperatoryEdit",
+    "endpoints": [
+      {
+        "path": "/api/operatories/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOperatoryPick.cs",
+    "formName": "FormOperatoryPick",
+    "endpoints": [
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoAutoClaims.cs",
+    "formName": "FormOrthoAutoClaims",
+    "endpoints": [
+      {
+        "path": "/api/ortho/auto-claims",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoCase.cs",
+    "formName": "FormOrthoCase",
+    "endpoints": [
+      {
+        "path": "/api/ortho/cases/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/cases/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoChart.cs",
+    "formName": "FormOrthoChart",
+    "endpoints": [
+      {
+        "path": "/api/ortho/charts/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/charts/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoChartSetup.cs",
+    "formName": "FormOrthoChartSetup",
+    "endpoints": [
+      {
+        "path": "/api/ortho/charts/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/charts/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareAdd.cs",
+    "formName": "FormOrthoHardwareAdd",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareEdit.cs",
+    "formName": "FormOrthoHardwareEdit",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/hardware/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareSpecEdit.cs",
+    "formName": "FormOrthoHardwareSpecEdit",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware/specs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/hardware/specs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareSpecs.cs",
+    "formName": "FormOrthoHardwareSpecs",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware/specs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoPat.cs",
+    "formName": "FormOrthoPat",
+    "endpoints": [
+      {
+        "path": "/api/ortho/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoRxEdit.cs",
+    "formName": "FormOrthoRxEdit",
+    "endpoints": [
+      {
+        "path": "/api/ortho/rx/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/rx/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoRxSelect.cs",
+    "formName": "FormOrthoRxSelect",
+    "endpoints": [
+      {
+        "path": "/api/ortho/rx",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoRxSetup.cs",
+    "formName": "FormOrthoRxSetup",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldCheckEdit.cs",
+    "formName": "FormPatFieldCheckEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldCurrencyEdit.cs",
+    "formName": "FormPatFieldCurrencyEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldDateEdit.cs",
+    "formName": "FormPatFieldDateEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldDefEdit.cs",
+    "formName": "FormPatFieldDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-field-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-field-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldDefs.cs",
+    "formName": "FormPatFieldDefs",
+    "endpoints": [
+      {
+        "path": "/api/patient-field-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldEdit.cs",
+    "formName": "FormPatFieldEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldPickEdit.cs",
+    "formName": "FormPatFieldPickEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatList2014.cs",
+    "formName": "FormPatList2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListEHR2014.cs",
+    "formName": "FormPatListEHR2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/ehr",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListElementEdit2014.cs",
+    "formName": "FormPatListElementEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/elements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-lists/elements/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListElementEditEHR2014.cs",
+    "formName": "FormPatListElementEditEHR2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/ehr/elements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-lists/ehr/elements/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListResults2014.cs",
+    "formName": "FormPatListResults2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListResultsEHR2014.cs",
+    "formName": "FormPatListResultsEHR2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/ehr/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPath.cs",
+    "formName": "FormPath",
+    "endpoints": [
+      {
+        "path": "/api/preferences/path",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/path",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientEdit.cs",
+    "formName": "FormPatientEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/email",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientForms.cs",
+    "formName": "FormPatientForms",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/forms",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/forms",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientListDiscount.cs",
+    "formName": "FormPatientListDiscount",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientMerge.cs",
+    "formName": "FormPatientMerge",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientPickWebForm.cs",
+    "formName": "FormPatientPickWebForm",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientPortal.cs",
+    "formName": "FormPatientPortal",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientStatusTool.cs",
+    "formName": "FormPatientStatusTool",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnect.cs",
+    "formName": "FormPayConnect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payconnect/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnect2.cs",
+    "formName": "FormPayConnect2",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/payconnect2/transactions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnect2iFrame.cs",
+    "formName": "FormPayConnect2iFrame",
+    "endpoints": [
+      {
+        "path": "/api/payconnect2/transactions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnectSetup.cs",
+    "formName": "FormPayConnectSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPeriodEdit.cs",
+    "formName": "FormPayPeriodEdit",
+    "endpoints": [
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPeriodManager.cs",
+    "formName": "FormPayPeriodManager",
+    "endpoints": [
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlan.cs",
+    "formName": "FormPayPlan",
+    "endpoints": [
+      {
+        "path": "/api/payplans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payplans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges?payPlanId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanChargeEdit.cs",
+    "formName": "FormPayPlanChargeEdit",
+    "endpoints": [
+      {
+        "path": "/api/payplan-charges/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanChargeSelection.cs",
+    "formName": "FormPayPlanChargeSelection",
+    "endpoints": [
+      {
+        "path": "/api/payplan-charges",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanCredits.cs",
+    "formName": "FormPayPlanCredits",
+    "endpoints": [
+      {
+        "path": "/api/payplan-credits?payPlanId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-credits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-credits/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanDynamic.cs",
+    "formName": "FormPayPlanDynamic",
+    "endpoints": [
+      {
+        "path": "/api/payplans/{id}/dynamic",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplans/{id}/dynamic",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanRecalculate.cs",
+    "formName": "FormPayPlanRecalculate",
+    "endpoints": [
+      {
+        "path": "/api/payplans/{id}/recalculate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanSelect.cs",
+    "formName": "FormPayPlanSelect",
+    "endpoints": [
+      {
+        "path": "/api/payplans?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanTemplateEdit.cs",
+    "formName": "FormPayPlanTemplateEdit",
+    "endpoints": [
+      {
+        "path": "/api/payplan-templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-templates/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-templates/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanTemplates.cs",
+    "formName": "FormPayPlanTemplates",
+    "endpoints": [
+      {
+        "path": "/api/payplan-templates",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-templates",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaySimple.cs",
+    "formName": "FormPaySimple",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/paysimple",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/paysimple/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/paysimple/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaySimpleSetup.cs",
+    "formName": "FormPaySimpleSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/paysimple",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/paysimple/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/paysimple/properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaySplitEdit.cs",
+    "formName": "FormPaySplitEdit",
+    "endpoints": [
+      {
+        "path": "/api/paysplits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayTerminalEdit.cs",
+    "formName": "FormPayTerminalEdit",
+    "endpoints": [
+      {
+        "path": "/api/payterminals/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payterminals/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayment.cs",
+    "formName": "FormPayment",
+    "endpoints": [
+      {
+        "path": "/api/payments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits?paymentId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaymentPlanOptions.cs",
+    "formName": "FormPaymentPlanOptions",
+    "endpoints": [
+      {
+        "path": "/api/preferences/payment-plan-options",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/payment-plan-options",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayorTypeEdit.cs",
+    "formName": "FormPayorTypeEdit",
+    "endpoints": [
+      {
+        "path": "/api/payor-types/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payor-types/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payor-types/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayorTypes.cs",
+    "formName": "FormPayorTypes",
+    "endpoints": [
+      {
+        "path": "/api/payor-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payor-types",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerio.cs",
+    "formName": "FormPerio",
+    "endpoints": [
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioEdit.cs",
+    "formName": "FormPerioEdit",
+    "endpoints": [
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioGraphical.cs",
+    "formName": "FormPerioGraphical",
+    "endpoints": [
+      {
+        "path": "/api/perio-exams/{id}/graph",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioGraphicalSetup.cs",
+    "formName": "FormPerioGraphicalSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences/perio-graphical",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/perio-graphical",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioSetup.cs",
+    "formName": "FormPerioSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences/perio",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/perio",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioVoice.cs",
+    "formName": "FormPerioVoice",
+    "endpoints": [
+      {
+        "path": "/api/preferences/perio-voice",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/perio-voice",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPharmacies.cs",
+    "formName": "FormPharmacies",
+    "endpoints": [
+      {
+        "path": "/api/pharmacies",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPharmacyEdit.cs",
+    "formName": "FormPharmacyEdit",
+    "endpoints": [
+      {
+        "path": "/api/pharmacies/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPhoneNumbersManage.cs",
+    "formName": "FormPhoneNumbersManage",
+    "endpoints": [
+      {
+        "path": "/api/phone-numbers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/phone-numbers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPlansForFamily.cs",
+    "formName": "FormPlansForFamily",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPodiumSetup.cs",
+    "formName": "FormPodiumSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/podium",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/podium/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/podium/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPopupDisplay.cs",
+    "formName": "FormPopupDisplay",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/popups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPopupFade.cs",
+    "formName": "FormPopupFade",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/popups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPopupsForFam.cs",
+    "formName": "FormPopupsForFam",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/popups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-popups",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-popups/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPractice.cs",
+    "formName": "FormPractice",
+    "endpoints": [
+      {
+        "path": "/api/practice",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/practice",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPreferences.cs",
+    "formName": "FormPreferences",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrepaymentEdit.cs",
+    "formName": "FormPrepaymentEdit",
+    "endpoints": [
+      {
+        "path": "/api/prepayments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prepayments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prepayments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrepaymentTool.cs",
+    "formName": "FormPrepaymentTool",
+    "endpoints": [
+      {
+        "path": "/api/prepayments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prepayments/allocate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrinterEdit.cs",
+    "formName": "FormPrinterEdit",
+    "endpoints": [
+      {
+        "path": "/api/printers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/printers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrinterSetup.cs",
+    "formName": "FormPrinterSetup",
+    "endpoints": [
+      {
+        "path": "/api/printers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/printers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/printers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrntScrn.cs",
+    "formName": "FormPrntScrn",
+    "endpoints": [
+      {
+        "path": "/api/screenshots",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcApptColorEdit.cs",
+    "formName": "FormProcApptColorEdit",
+    "endpoints": [
+      {
+        "path": "/api/proc-appt-colors/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-appt-colors/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcApptColors.cs",
+    "formName": "FormProcApptColors",
+    "endpoints": [
+      {
+        "path": "/api/proc-appt-colors",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-appt-colors",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-appt-colors/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcBandingSelect.cs",
+    "formName": "FormProcBandingSelect",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/banding",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcBroken.cs",
+    "formName": "FormProcBroken",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}/status",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/broken-reasons",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcButtonEdit.cs",
+    "formName": "FormProcButtonEdit",
+    "endpoints": [
+      {
+        "path": "/api/proc-buttons/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-buttons/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcButtonQuickEdit.cs",
+    "formName": "FormProcButtonQuickEdit",
+    "endpoints": [
+      {
+        "path": "/api/proc-buttons/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcButtons.cs",
+    "formName": "FormProcButtons",
+    "endpoints": [
+      {
+        "path": "/api/proc-buttons",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-buttons",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeEdit.cs",
+    "formName": "FormProcCodeEdit",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeEditMore.cs",
+    "formName": "FormProcCodeEditMore",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/{id}/details",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{id}/details",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeNew.cs",
+    "formName": "FormProcCodeNew",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeNoteEdit.cs",
+    "formName": "FormProcCodeNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/{id}/note",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodes2.cs",
+    "formName": "FormProcCodes2",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcEdit.cs",
+    "formName": "FormProcEdit",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcEditAll.cs",
+    "formName": "FormProcEditAll",
+    "endpoints": [
+      {
+        "path": "/api/procedures/batch",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcGroup.cs",
+    "formName": "FormProcGroup",
+    "endpoints": [
+      {
+        "path": "/api/procedures/group",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcLockTool.cs",
+    "formName": "FormProcLockTool",
+    "endpoints": [
+      {
+        "path": "/api/procedures/lock",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcNoteAppend.cs",
+    "formName": "FormProcNoteAppend",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}/notes",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcSelect.cs",
+    "formName": "FormProcSelect",
+    "endpoints": [
+      {
+        "path": "/api/procedures",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcTPEdit.cs",
+    "formName": "FormProcTPEdit",
+    "endpoints": [
+      {
+        "path": "/api/treatment-plans/{id}/procedures",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcTools.cs",
+    "formName": "FormProcTools",
+    "endpoints": [
+      {
+        "path": "/api/procedures/tools",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProdSelect.cs",
+    "formName": "FormProdSelect",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinkEdit.cs",
+    "formName": "FormProgramLinkEdit",
+    "endpoints": [
+      {
+        "path": "/api/program-links/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-links/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinkHideClinics.cs",
+    "formName": "FormProgramLinkHideClinics",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinkOutputFile .cs",
+    "formName": "FormProgramLinkOutputFile ",
+    "endpoints": [
+      {
+        "path": "/api/program-links/output-file",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinks.cs",
+    "formName": "FormProgramLinks",
+    "endpoints": [
+      {
+        "path": "/api/program-links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-links",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramProperty.cs",
+    "formName": "FormProgramProperty",
+    "endpoints": [
+      {
+        "path": "/api/program-properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvAdditional.cs",
+    "formName": "FormProvAdditional",
+    "endpoints": [
+      {
+        "path": "/api/providers/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/provider-identifiers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvEdit.cs",
+    "formName": "FormProvEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvStudentBulkEdit.cs",
+    "formName": "FormProvStudentBulkEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers/students/bulk",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvStudentEdit.cs",
+    "formName": "FormProvStudentEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers/students/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProviderMerge.cs",
+    "formName": "FormProviderMerge",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProviderMultiPick.cs",
+    "formName": "FormProviderMultiPick",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProviderSetup.cs",
+    "formName": "FormProviderSetup",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQBAccountSelect.cs",
+    "formName": "FormQBAccountSelect",
+    "endpoints": [
+      {
+        "path": "/api/accounting/accounts",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryEdit.cs",
+    "formName": "FormQueryEdit",
+    "endpoints": [
+      {
+        "path": "/api/queries/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryFavorites.cs",
+    "formName": "FormQueryFavorites",
+    "endpoints": [
+      {
+        "path": "/api/query-favorites",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/query-favorites",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryMonitor.cs",
+    "formName": "FormQueryMonitor",
+    "endpoints": [
+      {
+        "path": "/api/queries/running",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryParser.cs",
+    "formName": "FormQueryParser",
+    "endpoints": [
+      {
+        "path": "/api/queries/parse",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuestionDefEdit.cs",
+    "formName": "FormQuestionDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/question-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuestionDefs.cs",
+    "formName": "FormQuestionDefs",
+    "endpoints": [
+      {
+        "path": "/api/question-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/question-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuickBooksOnlineAuthorization.cs",
+    "formName": "FormQuickBooksOnlineAuthorization",
+    "endpoints": [
+      {
+        "path": "/api/quickbooks/online/authorize",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuickBooksOnlineSetup.cs",
+    "formName": "FormQuickBooksOnlineSetup",
+    "endpoints": [
+      {
+        "path": "/api/quickbooks/online/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuickBooksSetup.cs",
+    "formName": "FormQuickBooksSetup",
+    "endpoints": [
+      {
+        "path": "/api/quickbooks/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRadOrderList.cs",
+    "formName": "FormRadOrderList",
+    "endpoints": [
+      {
+        "path": "/api/radiology/orders",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReactivationEdit.cs",
+    "formName": "FormReactivationEdit",
+    "endpoints": [
+      {
+        "path": "/api/reactivations/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReactivationSetup.cs",
+    "formName": "FormReactivationSetup",
+    "endpoints": [
+      {
+        "path": "/api/reactivation-rules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/reactivation-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallEdit.cs",
+    "formName": "FormRecallEdit",
+    "endpoints": [
+      {
+        "path": "/api/recalls/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallList.cs",
+    "formName": "FormRecallList",
+    "endpoints": [
+      {
+        "path": "/api/recalls/list",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallListUndo.cs",
+    "formName": "FormRecallListUndo",
+    "endpoints": [
+      {
+        "path": "/api/recalls/undo",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallSetup.cs",
+    "formName": "FormRecallSetup",
+    "endpoints": [
+      {
+        "path": "/api/recalls/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallTypeEdit.cs",
+    "formName": "FormRecallTypeEdit",
+    "endpoints": [
+      {
+        "path": "/api/recall-types/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallTypes.cs",
+    "formName": "FormRecallTypes",
+    "endpoints": [
+      {
+        "path": "/api/recall-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recall-types",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallsPat.cs",
+    "formName": "FormRecallsPat",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/recalls",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileAllergy.cs",
+    "formName": "FormReconcileAllergy",
+    "endpoints": [
+      {
+        "path": "/api/allergies/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileEdit.cs",
+    "formName": "FormReconcileEdit",
+    "endpoints": [
+      {
+        "path": "/api/reconciles/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileMedication.cs",
+    "formName": "FormReconcileMedication",
+    "endpoints": [
+      {
+        "path": "/api/medications/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileProblem.cs",
+    "formName": "FormReconcileProblem",
+    "endpoints": [
+      {
+        "path": "/api/problems/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconciles.cs",
+    "formName": "FormReconciles",
+    "endpoints": [
+      {
+        "path": "/api/reconciles",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecordAudio.cs",
+    "formName": "FormRecordAudio",
+    "endpoints": [
+      {
+        "path": "/api/audio-recordings",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecurringChargesHistory.cs",
+    "formName": "FormRecurringChargesHistory",
+    "endpoints": [
+      {
+        "path": "/api/recurring-charges/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRedundantIndexes.cs",
+    "formName": "FormRedundantIndexes",
+    "endpoints": [
+      {
+        "path": "/api/database/indexes/redundant",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferenceEdit.cs",
+    "formName": "FormReferenceEdit",
+    "endpoints": [
+      {
+        "path": "/api/references/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferenceEntryEdit.cs",
+    "formName": "FormReferenceEntryEdit",
+    "endpoints": [
+      {
+        "path": "/api/reference-entries/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferenceSelect.cs",
+    "formName": "FormReferenceSelect",
+    "endpoints": [
+      {
+        "path": "/api/references",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferralMerge.cs",
+    "formName": "FormReferralMerge",
+    "endpoints": [
+      {
+        "path": "/api/referrals/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferralProcTrack.cs",
+    "formName": "FormReferralProcTrack",
+    "endpoints": [
+      {
+        "path": "/api/referral-procedures",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRegistrationKey.cs",
+    "formName": "FormRegistrationKey",
+    "endpoints": [
+      {
+        "path": "/api/registration-keys",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRegistrationKeyEdit.cs",
+    "formName": "FormRegistrationKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/registration-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReminderRuleEdit.cs",
+    "formName": "FormReminderRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/reminder-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReminderRules.cs",
+    "formName": "FormReminderRules",
+    "endpoints": [
+      {
+        "path": "/api/reminder-rules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/reminder-rules",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRepeatChargeEdit.cs",
+    "formName": "FormRepeatChargeEdit",
+    "endpoints": [
+      {
+        "path": "/api/repeat-charges/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRepeatChargeEditMulti.cs",
+    "formName": "FormRepeatChargeEditMulti",
+    "endpoints": [
+      {
+        "path": "/api/repeat-charges/bulk",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRepeatChargesUpdate.cs",
+    "formName": "FormRepeatChargesUpdate",
+    "endpoints": [
+      {
+        "path": "/api/repeat-charges/run",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReplicationEdit.cs",
+    "formName": "FormReplicationEdit",
+    "endpoints": [
+      {
+        "path": "/api/replication/servers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReplicationSetup.cs",
+    "formName": "FormReplicationSetup",
+    "endpoints": [
+      {
+        "path": "/api/replication/servers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/replication/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReportSetup.cs",
+    "formName": "FormReportSetup",
+    "endpoints": [
+      {
+        "path": "/api/reports/setup",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/reports/setup",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReportsFiltered.cs",
+    "formName": "FormReportsFiltered",
+    "endpoints": [
+      {
+        "path": "/api/reports/filter",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReportsMore.cs",
+    "formName": "FormReportsMore",
+    "endpoints": [
+      {
+        "path": "/api/reports",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqAppt.cs",
+    "formName": "FormReqAppt",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqFieldCondEdit.cs",
+    "formName": "FormReqFieldCondEdit",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/field-conditions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/requirements/{id}/field-conditions/{condId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqNeededEdit.cs",
+    "formName": "FormReqNeededEdit",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqNeededs.cs",
+    "formName": "FormReqNeededs",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqStudentEdit.cs",
+    "formName": "FormReqStudentEdit",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/students/{studentId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/requirements/{id}/students/{studentId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqStudentOne.cs",
+    "formName": "FormReqStudentOne",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/students/{studentId}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqStudentsMany.cs",
+    "formName": "FormReqStudentsMany",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/students",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRequestEdit.cs",
+    "formName": "FormRequestEdit",
+    "endpoints": [
+      {
+        "path": "/api/requests",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/requests/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRequiredFields.cs",
+    "formName": "FormRequiredFields",
+    "endpoints": [
+      {
+        "path": "/api/required-fields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/required-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormResellerEdit.cs",
+    "formName": "FormResellerEdit",
+    "endpoints": [
+      {
+        "path": "/api/resellers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/resellers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormResellerServiceEdit.cs",
+    "formName": "FormResellerServiceEdit",
+    "endpoints": [
+      {
+        "path": "/api/resellers/{id}/services/{serviceId}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormResellers.cs",
+    "formName": "FormResellers",
+    "endpoints": [
+      {
+        "path": "/api/resellers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRpEraAutoProcessed.cs",
+    "formName": "FormRpEraAutoProcessed",
+    "endpoints": [
+      {
+        "path": "/api/eras/auto-processed",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxAlertEdit.cs",
+    "formName": "FormRxAlertEdit",
+    "endpoints": [
+      {
+        "path": "/api/rx-alerts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/rx-alerts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxCombine.cs",
+    "formName": "FormRxCombine",
+    "endpoints": [
+      {
+        "path": "/api/prescriptions/combine",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxDefEdit.cs",
+    "formName": "FormRxDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxEdit.cs",
+    "formName": "FormRxEdit",
+    "endpoints": [
+      {
+        "path": "/api/prescriptions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prescriptions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxManage.cs",
+    "formName": "FormRxManage",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/prescriptions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxNorms.cs",
+    "formName": "FormRxNorms",
+    "endpoints": [
+      {
+        "path": "/api/rxnorms/search",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxSelect.cs",
+    "formName": "FormRxSelect",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxSetup.cs",
+    "formName": "FormRxSetup",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScannerSetup.cs",
+    "formName": "FormScannerSetup",
+    "endpoints": [
+      {
+        "path": "/api/scanner-settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/scanner-settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchedule.cs",
+    "formName": "FormSchedule",
+    "endpoints": [
+      {
+        "path": "/api/schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/schedules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduleBlockEdit.cs",
+    "formName": "FormScheduleBlockEdit",
+    "endpoints": [
+      {
+        "path": "/api/schedule-blocks/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/schedule-blocks/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduleDayEdit.cs",
+    "formName": "FormScheduleDayEdit",
+    "endpoints": [
+      {
+        "path": "/api/schedule-days/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduleEdit.cs",
+    "formName": "FormScheduleEdit",
+    "endpoints": [
+      {
+        "path": "/api/schedules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/schedules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduledProcesses.cs",
+    "formName": "FormScheduledProcesses",
+    "endpoints": [
+      {
+        "path": "/api/scheduled-processes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/scheduled-processes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduledProcessesEdit.cs",
+    "formName": "FormScheduledProcessesEdit",
+    "endpoints": [
+      {
+        "path": "/api/scheduled-processes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/scheduled-processes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolClassEdit.cs",
+    "formName": "FormSchoolClassEdit",
+    "endpoints": [
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolClasses.cs",
+    "formName": "FormSchoolClasses",
+    "endpoints": [
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolCourseEdit.cs",
+    "formName": "FormSchoolCourseEdit",
+    "endpoints": [
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolCourses.cs",
+    "formName": "FormSchoolCourses",
+    "endpoints": [
+      {
+        "path": "/api/school-classes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/school-classes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScreenEdit.cs",
+    "formName": "FormScreenEdit",
+    "endpoints": [
+      {
+        "path": "/api/screens/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/screens/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScreenGroupEdit.cs",
+    "formName": "FormScreenGroupEdit",
+    "endpoints": [
+      {
+        "path": "/api/screen-groups/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/screen-groups/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScreenGroups.cs",
+    "formName": "FormScreenGroups",
+    "endpoints": [
+      {
+        "path": "/api/screen-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/screen-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecureEmailSetup.cs",
+    "formName": "FormSecureEmailSetup",
+    "endpoints": [
+      {
+        "path": "/api/secure-email/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/secure-email/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecurity.cs",
+    "formName": "FormSecurity",
+    "endpoints": [
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/user-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/permissions",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecurityCentralUserEdit.cs",
+    "formName": "FormSecurityCentralUserEdit",
+    "endpoints": [
+      {
+        "path": "/api/central-users/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/central-users/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecurityLock.cs",
+    "formName": "FormSecurityLock",
+    "endpoints": [
+      {
+        "path": "/api/security/lock",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security/unlock",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSetupWizard.cs",
+    "formName": "FormSetupWizard",
+    "endpoints": [
+      {
+        "path": "/api/setup-wizard",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/setup-wizard",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSetupWizardProgress.cs",
+    "formName": "FormSetupWizardProgress",
+    "endpoints": [
+      {
+        "path": "/api/setup-wizard/progress/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDef.cs",
+    "formName": "FormSheetDef",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDefDefaults.cs",
+    "formName": "FormSheetDefDefaults",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs/defaults",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/defaults",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDefEdit.cs",
+    "formName": "FormSheetDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDefs.cs",
+    "formName": "FormSheetDefs",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetExport.cs",
+    "formName": "FormSheetExport",
+    "endpoints": [
+      {
+        "path": "/api/sheets/export",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldAdd.cs",
+    "formName": "FormSheetFieldAdd",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldChart.cs",
+    "formName": "FormSheetFieldChart",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/chart",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldCheckBox.cs",
+    "formName": "FormSheetFieldCheckBox",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/checkbox",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldComboBox.cs",
+    "formName": "FormSheetFieldComboBox",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/combobox",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldEditPatImage.cs",
+    "formName": "FormSheetFieldEditPatImage",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/pat-image/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldExam.cs",
+    "formName": "FormSheetFieldExam",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/exam",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldGrid.cs",
+    "formName": "FormSheetFieldGrid",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/grid",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldImage.cs",
+    "formName": "FormSheetFieldImage",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/image",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldInput.cs",
+    "formName": "FormSheetFieldInput",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/input",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldLine.cs",
+    "formName": "FormSheetFieldLine",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/line",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldOutput.cs",
+    "formName": "FormSheetFieldOutput",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/output",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldPatImage.cs",
+    "formName": "FormSheetFieldPatImage",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/patient-image",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldRect.cs",
+    "formName": "FormSheetFieldRect",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/rect",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldSigBox.cs",
+    "formName": "FormSheetFieldSigBox",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/signature",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldSpecial.cs",
+    "formName": "FormSheetFieldSpecial",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/special",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldStatic.cs",
+    "formName": "FormSheetFieldStatic",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/static",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFillEdit.cs",
+    "formName": "FormSheetFillEdit",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fills/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetImport.cs",
+    "formName": "FormSheetImport",
+    "endpoints": [
+      {
+        "path": "/api/sheets/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetImportEnumPicker.cs",
+    "formName": "FormSheetImportEnumPicker",
+    "endpoints": [
+      {
+        "path": "/api/sheets/import-enums",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetOutputFormat.cs",
+    "formName": "FormSheetOutputFormat",
+    "endpoints": [
+      {
+        "path": "/api/sheets/output-format",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetProcSelect.cs",
+    "formName": "FormSheetProcSelect",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetTools.cs",
+    "formName": "FormSheetTools",
+    "endpoints": [
+      {
+        "path": "/api/sheets/tools/copy",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormShowFeatures.cs",
+    "formName": "FormShowFeatures",
+    "endpoints": [
+      {
+        "path": "/api/preferences/features",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/features",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormShutdown.cs",
+    "formName": "FormShutdown",
+    "endpoints": [
+      {
+        "path": "/api/system/shutdown",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSigButDefEdit.cs",
+    "formName": "FormSigButDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/sig-button-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-button-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-button-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSigElementDefEdit.cs",
+    "formName": "FormSigElementDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/sig-element-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-element-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-element-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSmsTextMessaging.cs",
+    "formName": "FormSmsTextMessaging",
+    "endpoints": [
+      {
+        "path": "/api/sms/messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sms/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sms/messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sms/credits",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSnomeds.cs",
+    "formName": "FormSnomeds",
+    "endpoints": [
+      {
+        "path": "/api/snomeds",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSpellCheck.cs",
+    "formName": "FormSpellCheck",
+    "endpoints": [
+      {
+        "path": "/api/spell-check",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSpellChecker.cs",
+    "formName": "FormSpellChecker",
+    "endpoints": [
+      {
+        "path": "/api/spell-check",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSplash.cs",
+    "formName": "FormSplash",
+    "endpoints": [
+      {
+        "path": "/api/application/version",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/server/time",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormStateAbbrEdit.cs",
+    "formName": "FormStateAbbrEdit",
+    "endpoints": [
+      {
+        "path": "/api/state-abbreviations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/state-abbreviations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/state-abbreviations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormStateAbbrs.cs",
+    "formName": "FormStateAbbrs",
+    "endpoints": [
+      {
+        "path": "/api/state-abbreviations",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormStatementOptions.cs",
+    "formName": "FormStatementOptions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/statements/options",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSubscriberMove .cs",
+    "formName": "FormSubscriberMove ",
+    "endpoints": [
+      {
+        "path": "/api/subscribers/{id}/move",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/insurance-plans/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSubscriberSelect.cs",
+    "formName": "FormSubscriberSelect",
+    "endpoints": [
+      {
+        "path": "/api/subscribers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSubscribersList.cs",
+    "formName": "FormSubscribersList",
+    "endpoints": [
+      {
+        "path": "/api/subscribers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplierEdit.cs",
+    "formName": "FormSupplierEdit",
+    "endpoints": [
+      {
+        "path": "/api/suppliers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/suppliers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/suppliers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSuppliers.cs",
+    "formName": "FormSuppliers",
+    "endpoints": [
+      {
+        "path": "/api/suppliers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplies.cs",
+    "formName": "FormSupplies",
+    "endpoints": [
+      {
+        "path": "/api/supplies",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/supplies",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyEdit.cs",
+    "formName": "FormSupplyEdit",
+    "endpoints": [
+      {
+        "path": "/api/supplies/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/supplies/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyInventory.cs",
+    "formName": "FormSupplyInventory",
+    "endpoints": [
+      {
+        "path": "/api/supplies/inventory",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/supplies/inventory",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyOrderEdit.cs",
+    "formName": "FormSupplyOrderEdit",
+    "endpoints": [
+      {
+        "path": "/api/supply-orders",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyOrderItemEdit.cs",
+    "formName": "FormSupplyOrderItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/supply-orders/{orderId}/items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{orderId}/items/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{orderId}/items/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyOrders.cs",
+    "formName": "FormSupplyOrders",
+    "endpoints": [
+      {
+        "path": "/api/supply-orders",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupportStatus.cs",
+    "formName": "FormSupportStatus",
+    "endpoints": [
+      {
+        "path": "/api/support/status",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTPsign.cs",
+    "formName": "FormTPsign",
+    "endpoints": [
+      {
+        "path": "/api/treat-plans/{id}/signature",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskAttachmentEdit.cs",
+    "formName": "FormTaskAttachmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/attachments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskAttachments.cs",
+    "formName": "FormTaskAttachments",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/attachments",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskEdit.cs",
+    "formName": "FormTaskEdit",
+    "endpoints": [
+      {
+        "path": "/api/tasks",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskHist.cs",
+    "formName": "FormTaskHist",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{id}/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskInboxSetup.cs",
+    "formName": "FormTaskInboxSetup",
+    "endpoints": [
+      {
+        "path": "/api/task-lists",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/inbox",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskListBlock.cs",
+    "formName": "FormTaskListBlock",
+    "endpoints": [
+      {
+        "path": "/api/task-lists/{id}/block",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/{id}/block",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskListEdit.cs",
+    "formName": "FormTaskListEdit",
+    "endpoints": [
+      {
+        "path": "/api/task-lists",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskListSelect.cs",
+    "formName": "FormTaskListSelect",
+    "endpoints": [
+      {
+        "path": "/api/task-lists",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskNoteEdit.cs",
+    "formName": "FormTaskNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/notes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/notes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskOptions.cs",
+    "formName": "FormTaskOptions",
+    "endpoints": [
+      {
+        "path": "/api/preferences/task-options",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/task-options",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskPreferences.cs",
+    "formName": "FormTaskPreferences",
+    "endpoints": [
+      {
+        "path": "/api/preferences/task",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/task",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskSearch.cs",
+    "formName": "FormTaskSearch",
+    "endpoints": [
+      {
+        "path": "/api/tasks/search",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskSubscribers.cs",
+    "formName": "FormTaskSubscribers",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/subscribers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/subscribers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/subscribers/{userId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTasks.cs",
+    "formName": "FormTasks",
+    "endpoints": [
+      {
+        "path": "/api/tasks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTasksForAppt.cs",
+    "formName": "FormTasksForAppt",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}/tasks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}/tasks",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaxAddress.cs",
+    "formName": "FormTaxAddress",
+    "endpoints": [
+      {
+        "path": "/api/addresses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/addresses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/addresses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/addresses/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTelephone.cs",
+    "formName": "FormTelephone",
+    "endpoints": [
+      {
+        "path": "/api/patients/reformat-phone-numbers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTerminal.cs",
+    "formName": "FormTerminal",
+    "endpoints": [
+      {
+        "path": "/api/terminalactives",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives?computerName={name}&sessionId={sessionId}&processId={processId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives?computerName={name}&sessionId={sessionId}&processId={processId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sheets?patNum={patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/signalods",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTerminalConnection.cs",
+    "formName": "FormTerminalConnection",
+    "endpoints": [
+      {
+        "path": "/api/terminals/connect",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTerminalManager.cs",
+    "formName": "FormTerminalManager",
+    "endpoints": [
+      {
+        "path": "/api/terminalactives",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/mobileappdevices",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheets?patNum={patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheets/checkin?aptNum={aptNum}",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments?patNum={patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?name=TerminalClosePassword",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/signalods",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTestLatency.cs",
+    "formName": "FormTestLatency",
+    "endpoints": [
+      {
+        "path": "/api/misc/version",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeAdjustEdit.cs",
+    "formName": "FormTimeAdjustEdit",
+    "endpoints": [
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=TimeCardAdjTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods?date={date}&employeeId={employeeNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCard.cs",
+    "formName": "FormTimeCard",
+    "endpoints": [
+      {
+        "path": "/api/clockevents?employeeNum={employeeNum}&start={start}&end={end}&isBreaks={isBreaks}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts?employeeNum={employeeNum}&start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?category=TimeCard",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/misc/now",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardBenefitsRp.cs",
+    "formName": "FormTimeCardBenefitsRp",
+    "endpoints": [
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clockevents?start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts?start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/misc/now",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardManage.cs",
+    "formName": "FormTimeCardManage",
+    "endpoints": [
+      {
+        "path": "/api/clockevents/timecardmanage?start={start}&end={end}&clinicNum={clinicNum}&all={isAll}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?names=TimeCardsUseDecimalInsteadOfColon,TimeCardShowSeconds",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardRuleEdit.cs",
+    "formName": "FormTimeCardRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/employees?clinicNum={clinicNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardSetup.cs",
+    "formName": "FormTimeCardSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences?names=TimeCardsUseDecimalInsteadOfColon,TimeCardsMakesAdjustmentsForOverBreaks,TimeCardShowSeconds,ADPRunIID,ADPCompanyCode",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/{name}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clockevents?start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimePick.cs",
+    "formName": "FormTimePick",
+    "endpoints": [
+      {
+        "path": "/api/time/server",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormToothChartBig.cs",
+    "formName": "FormToothChartBig",
+    "endpoints": [
+      {
+        "path": "/api/preferences?name=UseInternationalToothNumbers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ChartGraphicColors",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computerprefs?computerName={computerName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computerprefs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrackNext.cs",
+    "formName": "FormTrackNext",
+    "endpoints": [
+      {
+        "path": "/api/appointments/plannedtracker?order={order}&provNum={provNum}&siteNum={siteNum}&clinicNum={clinicNum}&codeStart={codeStart}&codeEnd={codeEnd}&dateFrom={dateFrom}&dateTo={dateTo}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sites",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?names=PlannedApptDaysPast,PlannedApptDaysFuture,EasyHidePublicHealth,EnterpriseApptList",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrackNextSetup.cs",
+    "formName": "FormTrackNextSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences?name=PlannedApptDaysPast",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?name=PlannedApptDaysFuture",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/PlannedApptDaysPast",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/PlannedApptDaysFuture",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTransactionEdit.cs",
+    "formName": "FormTransactionEdit",
+    "endpoints": [
+      {
+        "path": "/api/transactions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/transactions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/transactions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries?transactionId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts/{accountNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{depositNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{payNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/transactioninvoices/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTranslation.cs",
+    "formName": "FormTranslation",
+    "endpoints": [
+      {
+        "path": "/api/translations?classType={type}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/translations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTranslationCat.cs",
+    "formName": "FormTranslationCat",
+    "endpoints": [
+      {
+        "path": "/api/translations/categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/export",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTranslationEdit.cs",
+    "formName": "FormTranslationEdit",
+    "endpoints": [
+      {
+        "path": "/api/translations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTransworldSetup.cs",
+    "formName": "FormTransworldSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/transworld",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/transworld",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=Transworld",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTreatPlanCurEdit.cs",
+    "formName": "FormTreatPlanCurEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTreatPlanDiscount.cs",
+    "formName": "FormTreatPlanDiscount",
+    "endpoints": [
+      {
+        "path": "/api/prefs/TreatPlanDiscountPercent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTreatPlanEdit.cs",
+    "formName": "FormTreatPlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/treatment-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrojanCollect.cs",
+    "formName": "FormTrojanCollect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/employers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/trojan/collect",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrojanCollectSetup.cs",
+    "formName": "FormTrojanCollectSetup",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=BillingTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/trojan-collect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/trojan-collect",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrojanHelp.cs",
+    "formName": "FormTrojanHelp",
+    "endpoints": [
+      {
+        "path": "/api/trojan/help",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTsiHistory.cs",
+    "formName": "FormTsiHistory",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/tsi-translogs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTxtMsgEdit.cs",
+    "formName": "FormTxtMsgEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/text-messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/text-messages/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/text-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTxtMsgMany.cs",
+    "formName": "FormTxtMsgMany",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/text-messages/bulk",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUcums.cs",
+    "formName": "FormUcums",
+    "endpoints": [
+      {
+        "path": "/api/ucums?search={text}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUnsched.cs",
+    "formName": "FormUnsched",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appointments?status=unscheduled",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/sites",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUnschedListPatient.cs",
+    "formName": "FormUnschedListPatient",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUnschedListSetup.cs",
+    "formName": "FormUnschedListSetup",
+    "endpoints": [
+      {
+        "path": "/api/prefs/UnschedDaysPast",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UnschedDaysFuture",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UnschedDaysPast",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UnschedDaysFuture",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdate.cs",
+    "formName": "FormUpdate",
+    "endpoints": [
+      {
+        "path": "/api/updates",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateHistory.cs",
+    "formName": "FormUpdateHistory",
+    "endpoints": [
+      {
+        "path": "/api/updates/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateInProgress.cs",
+    "formName": "FormUpdateInProgress",
+    "endpoints": [
+      {
+        "path": "/api/updates/in-progress",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateInstallMsg.cs",
+    "formName": "FormUpdateInstallMsg",
+    "endpoints": [
+      {
+        "path": "/api/updates/install-message",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateSetup.cs",
+    "formName": "FormUpdateSetup",
+    "endpoints": [
+      {
+        "path": "/api/updates/setup",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserEdit.cs",
+    "formName": "FormUserEdit",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserPassword.cs",
+    "formName": "FormUserPassword",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}/password",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserPrefAdditional.cs",
+    "formName": "FormUserPrefAdditional",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}/preferences",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserQuery.cs",
+    "formName": "FormUserQuery",
+    "endpoints": [
+      {
+        "path": "/api/user-queries",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVaccineDefEdit.cs",
+    "formName": "FormVaccineDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/vaccine-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVaccineDefSetup.cs",
+    "formName": "FormVaccineDefSetup",
+    "endpoints": [
+      {
+        "path": "/api/vaccine-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/vaccine-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVaccineObsEdit.cs",
+    "formName": "FormVaccineObsEdit",
+    "endpoints": [
+      {
+        "path": "/api/vaccine-observations/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVideo.cs",
+    "formName": "FormVideo",
+    "endpoints": [
+      {
+        "path": "/api/videos/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVitalsignEdit2014.cs",
+    "formName": "FormVitalsignEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/vital-signs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebBrowser.cs",
+    "formName": "FormWebBrowser",
+    "endpoints": [
+      {
+        "path": "/api/web-browser",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebBrowserPrefs.cs",
+    "formName": "FormWebBrowserPrefs",
+    "endpoints": [
+      {
+        "path": "/api/web-browser/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatSession.cs",
+    "formName": "FormWebChatSession",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes/{noteId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/end",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients?phone={phone}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatSessionNoteEdit.cs",
+    "formName": "FormWebChatSessionNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes/{noteId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes/{noteId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatSurveys.cs",
+    "formName": "FormWebChatSurveys",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/surveys",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatTools.cs",
+    "formName": "FormWebChatTools",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/messages?sessionIds={ids}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients?ids={ids}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebFormNextForms.cs",
+    "formName": "FormWebFormNextForms",
+    "endpoints": [
+      {
+        "path": "/api/webforms/next",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebFormSetup.cs",
+    "formName": "FormWebFormSetup",
+    "endpoints": [
+      {
+        "path": "/api/web-forms/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/web-forms/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/web-forms/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebForms.cs",
+    "formName": "FormWebForms",
+    "endpoints": [
+      {
+        "path": "/api/web-forms/forms",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/web-forms/forms/acknowledge",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/web-forms/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebMailMessageEdit.cs",
+    "formName": "FormWebMailMessageEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/family-phi",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses/notify",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users?withProviders=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/web-mail/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/web-mail/messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedASAPHistory.cs",
+    "formName": "FormWebSchedASAPHistory",
+    "endpoints": [
+      {
+        "path": "/api/asap-communications/history",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedASAPSend.cs",
+    "formName": "FormWebSchedASAPSend",
+    "endpoints": [
+      {
+        "path": "/api/clinic-prefs/{clinicId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/communications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/asap-communications",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedAppts.cs",
+    "formName": "FormWebSchedAppts",
+    "endpoints": [
+      {
+        "path": "/api/appointments/web-sched",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ApptConfirmed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedCarrierRule.cs",
+    "formName": "FormWebSchedCarrierRule",
+    "endpoints": [
+      {
+        "path": "/api/web-sched-carrier-rules",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedCarrierRuleCopyToClinics.cs",
+    "formName": "FormWebSchedCarrierRuleCopyToClinics",
+    "endpoints": [
+      {
+        "path": "/api/web-sched-carrier-rules/copy",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedCarrierRuleEdit.cs",
+    "formName": "FormWebSchedCarrierRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/web-sched-carrier-rules",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebView.cs",
+    "formName": "FormWebView",
+    "endpoints": [
+      {
+        "path": "/api/webview",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWiki.cs",
+    "formName": "FormWiki",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/user-prefs/{userId}/wiki-homepage",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiAllPages.cs",
+    "formName": "FormWikiAllPages",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiCompare.cs",
+    "formName": "FormWikiCompare",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/revisions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiDrafts.cs",
+    "formName": "FormWikiDrafts",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/drafts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/drafts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiEdit.cs",
+    "formName": "FormWikiEdit",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiFileFolder.cs",
+    "formName": "FormWikiFileFolder",
+    "endpoints": [
+      {
+        "path": "/api/wiki/files",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/files",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiHistory.cs",
+    "formName": "FormWikiHistory",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiIncomingLinks.cs",
+    "formName": "FormWikiIncomingLinks",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/incoming-links",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListEdit.cs",
+    "formName": "FormWikiListEdit",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListHeaders.cs",
+    "formName": "FormWikiListHeaders",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{id}/headers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{id}/headers",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListHistory.cs",
+    "formName": "FormWikiListHistory",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{id}/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListItemEdit.cs",
+    "formName": "FormWikiListItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{listId}/items/{itemId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{listId}/items/{itemId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{listId}/items",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiLists.cs",
+    "formName": "FormWikiLists",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiSearch.cs",
+    "formName": "FormWikiSearch",
+    "endpoints": [
+      {
+        "path": "/api/wiki/search",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXChargeReconcile.cs",
+    "formName": "FormXChargeReconcile",
+    "endpoints": [
+      {
+        "path": "/api/xcharge/transactions/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXDRSetup.cs",
+    "formName": "FormXDRSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/xdr",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xdr/properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXWeb.cs",
+    "formName": "FormXWeb",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/xweb/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXWebTransactions.cs",
+    "formName": "FormXWebTransactions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/xweb/transactions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXchargeSetup.cs",
+    "formName": "FormXchargeSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/xcharge",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xcharge/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/payment-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXchargeTokenTool.cs",
+    "formName": "FormXchargeTokenTool",
+    "endpoints": [
+      {
+        "path": "/api/programs/xcharge",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/tokens",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/xcharge/tokens/verify",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXchargeTrans.cs",
+    "formName": "FormXchargeTrans",
+    "endpoints": [
+      {
+        "path": "/api/preferences/storecctokens",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xcharge",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xcharge/properties",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Added placeholder API routes for 51 previously unmapped OpenDental forms
- Ensured all forms in form-api.json reference at least one endpoint for replatforming planning

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build PractxAPI.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b1a0f0d1e48323aa3a55871f894875