### PR TITLE
Map endpoints for remaining user forms

### DIFF
--- a/PractxAPI/Controllers/PlaceholderEndpointsController.cs
+++ b/PractxAPI/Controllers/PlaceholderEndpointsController.cs
@@ -1,0 +1,4675 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+
+namespace PractxAPI.Controllers;
+
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+public class PlaceholderEndpointsController : ControllerBase
+{
+    [HttpDelete("/api/accounting-auto-pays/{id}")]
+    public IActionResult DELETE_api_accounting_auto_pays__id__94c1b61d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/addresses/{id}")]
+    public IActionResult DELETE_api_addresses__id__8c05d64a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/adjustments/{id}")]
+    public IActionResult DELETE_api_adjustments__id__67327bf4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/alerts/{id}")]
+    public IActionResult DELETE_api_alerts__id__288aee3e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/allergy-defs/{id}")]
+    public IActionResult DELETE_api_allergy_defs__id__3ee9fe91() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/anesthesia/medications/{id}")]
+    public IActionResult DELETE_api_anesthesia_medications__id__9bfa81ca() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/anesthesia/medications/{medId}/doses/{doseId}")]
+    public IActionResult DELETE_api_anesthesia_medications__medId__doses__doseId__c4ca1929() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/anesthetic-records/{id}")]
+    public IActionResult DELETE_api_anesthetic_records__id__f206fe51() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/anesthetic-records/{id}/medications/{medId}")]
+    public IActionResult DELETE_api_anesthetic_records__id__medications__medId__05fe1bf0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/appointments/{id}")]
+    public IActionResult DELETE_api_appointments__id__3d3f4fc4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/appt-field-defs/{id}")]
+    public IActionResult DELETE_api_appt_field_defs__id__8aa20b17() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/appt-reminder-rules/{id}")]
+    public IActionResult DELETE_api_appt_reminder_rules__id__79ec8ab8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/appt-rules/{id}")]
+    public IActionResult DELETE_api_appt_rules__id__d789566e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/appt-types/{id}")]
+    public IActionResult DELETE_api_appt_types__id__7b9a69af() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/auto-code-conds")]
+    public IActionResult DELETE_api_auto_code_conds_b048230e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/auto-code-items/{id}")]
+    public IActionResult DELETE_api_auto_code_items__id__2e8b5d6d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/auto-codes/{id}")]
+    public IActionResult DELETE_api_auto_codes__id__d96609e7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/auto-comm-exclude-dates/{id}")]
+    public IActionResult DELETE_api_auto_comm_exclude_dates__id__279fcc6d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/auto-note-controls/{id}")]
+    public IActionResult DELETE_api_auto_note_controls__id__9080b267() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/auto-notes/{id}")]
+    public IActionResult DELETE_api_auto_notes__id__cb8db291() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/automation-conditions/{id}")]
+    public IActionResult DELETE_api_automation_conditions__id__3012b815() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/automations/{id}")]
+    public IActionResult DELETE_api_automations__id__edf0008b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/automations/{id}/conditions")]
+    public IActionResult DELETE_api_automations__id__conditions_9da32f7f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/benefits/{id}")]
+    public IActionResult DELETE_api_benefits__id__4a519961() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/blockouts")]
+    public IActionResult DELETE_api_blockouts_0aca77c7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/blockouts/duplicates")]
+    public IActionResult DELETE_api_blockouts_duplicates_3c0c1cf4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/carriers/{id}")]
+    public IActionResult DELETE_api_carriers__id__8f85f6fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/cds-triggers/{id}")]
+    public IActionResult DELETE_api_cds_triggers__id__07dd5f4e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/central-users/{id}")]
+    public IActionResult DELETE_api_central_users__id__0cf10b95() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/cert-employees/{id}")]
+    public IActionResult DELETE_api_cert_employees__id__a229f2d5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/certs/{id}")]
+    public IActionResult DELETE_api_certs__id__b17effaa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/chart-views/{id}")]
+    public IActionResult DELETE_api_chart_views__id__0e20410f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/chart-views/{id}/display-fields")]
+    public IActionResult DELETE_api_chart_views__id__display_fields_5182cfd3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claim-attachments/{id}")]
+    public IActionResult DELETE_api_claim_attachments__id__313e6069() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claim-forms/{id}")]
+    public IActionResult DELETE_api_claim_forms__id__1f1bf48d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claim-forms/{id}/items/{itemId}")]
+    public IActionResult DELETE_api_claim_forms__id__items__itemId__9ac9e677() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claim-payments/{id}")]
+    public IActionResult DELETE_api_claim_payments__id__584e2fa2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claim-procs/{id}")]
+    public IActionResult DELETE_api_claim_procs__id__343ff41e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claims/{id}")]
+    public IActionResult DELETE_api_claims__id__ac56fcb4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/claims/{id}/attachments/{attachId}")]
+    public IActionResult DELETE_api_claims__id__attachments__attachId__ba0b7743() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/clearinghouses/{id}")]
+    public IActionResult DELETE_api_clearinghouses__id__d41a5379() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/clock-events/{id}")]
+    public IActionResult DELETE_api_clock_events__id__1b223253() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/cloud-users/{id}")]
+    public IActionResult DELETE_api_cloud_users__id__0695b42e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/cloud/sessions/{id}")]
+    public IActionResult DELETE_api_cloud_sessions__id__c2853e4a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/code-groups/{id}")]
+    public IActionResult DELETE_api_code_groups__id__f6a27c00() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/computers/{id}")]
+    public IActionResult DELETE_api_computers__id__302c8a8e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/contacts/{id}")]
+    public IActionResult DELETE_api_contacts__id__67fb9bd5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/counties/{id}")]
+    public IActionResult DELETE_api_counties__id__a5998b8e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/cpts/{id}")]
+    public IActionResult DELETE_api_cpts__id__764f5dbd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/credit-cards/{id}")]
+    public IActionResult DELETE_api_credit_cards__id__bb929ec6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/def-links")]
+    public IActionResult DELETE_api_def_links_6308f054() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/definitions/{id}")]
+    public IActionResult DELETE_api_definitions__id__e7c270c0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/deposits/{id}")]
+    public IActionResult DELETE_api_deposits__id__be1693f7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/discount-plan-subs/{id}")]
+    public IActionResult DELETE_api_discount_plan_subs__id__21c9bc84() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/discount-plans/{id}")]
+    public IActionResult DELETE_api_discount_plans__id__66a3ae62() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/eclipboards/definitions/{id}")]
+    public IActionResult DELETE_api_eclipboards_definitions__id__bad1e39b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/eclipboards/imagecapturedefs/{id}")]
+    public IActionResult DELETE_api_eclipboards_imagecapturedefs__id__8bf59c03() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/eclipboards/sheetrules/{id}")]
+    public IActionResult DELETE_api_eclipboards_sheetrules__id__c0558e34() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/edu-resources/{id}")]
+    public IActionResult DELETE_api_edu_resources__id__80a3abe1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/amendments/{id}")]
+    public IActionResult DELETE_api_ehr_amendments__id__05411994() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/apt-observations/{id}")]
+    public IActionResult DELETE_api_ehr_apt_observations__id__b5167a6a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/care-plans/{id}")]
+    public IActionResult DELETE_api_ehr_care_plans__id__d15136ef() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/not-performed/{id}")]
+    public IActionResult DELETE_api_ehr_not_performed__id__b0edff07() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/quarterly-keys/{id}")]
+    public IActionResult DELETE_api_ehr_quarterly_keys__id__2f096204() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/vaccine-defs/{id}")]
+    public IActionResult DELETE_api_ehr_vaccine_defs__id__9736b6e3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/ehr/vaccines/{id}")]
+    public IActionResult DELETE_api_ehr_vaccines__id__f743c3d9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/elect-ids/{id}")]
+    public IActionResult DELETE_api_elect_ids__id__8148995d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/email-addresses/{id}")]
+    public IActionResult DELETE_api_email_addresses__id__280c97f4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/email-autographs/{id}")]
+    public IActionResult DELETE_api_email_autographs__id__fcc84d8b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/email-messages/{id}")]
+    public IActionResult DELETE_api_email_messages__id__4ce45809() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/email-templates/{id}")]
+    public IActionResult DELETE_api_email_templates__id__e89c6b1d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/employees/{id}")]
+    public IActionResult DELETE_api_employees__id__c9735539() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/employers/{id}")]
+    public IActionResult DELETE_api_employers__id__f3c96ca7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/encounters/{id}")]
+    public IActionResult DELETE_api_encounters__id__37de0e06() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/equipment/{id}")]
+    public IActionResult DELETE_api_equipment__id__69fed7da() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/eroutingdefs/{id}")]
+    public IActionResult DELETE_api_eroutingdefs__id__17cc02a8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/eservices/mobileapp/devices/{id}")]
+    public IActionResult DELETE_api_eservices_mobileapp_devices__id__fb8c4980() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/etrans/270/{id}")]
+    public IActionResult DELETE_api_etrans_270__id__46267f7e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/etrans/835/claims/{id}")]
+    public IActionResult DELETE_api_etrans_835_claims__id__30349895() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/etrans/{id}")]
+    public IActionResult DELETE_api_etrans__id__32127290() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/evaluation-criterion-defs/{id}")]
+    public IActionResult DELETE_api_evaluation_criterion_defs__id__eb4f4637() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/evaluation-defs/{id}")]
+    public IActionResult DELETE_api_evaluation_defs__id__d94a177c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/evaluations/{id}")]
+    public IActionResult DELETE_api_evaluations__id__4481f982() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/exam-sheets/{id}")]
+    public IActionResult DELETE_api_exam_sheets__id__e78ef526() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/fee-schedule-groups/{id}")]
+    public IActionResult DELETE_api_fee_schedule_groups__id__237706cd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/fee-schedules/{id}")]
+    public IActionResult DELETE_api_fee_schedules__id__7b572efb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/fees/{id}")]
+    public IActionResult DELETE_api_fees__id__7a549f74() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/fhir/api-keys/assign")]
+    public IActionResult DELETE_api_fhir_api_keys_assign_6af23acf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/fhir/api-keys/{id}")]
+    public IActionResult DELETE_api_fhir_api_keys__id__238235a8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/field-def-links/{id}")]
+    public IActionResult DELETE_api_field_def_links__id__07c2a1fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/grading-scales/{id}")]
+    public IActionResult DELETE_api_grading_scales__id__a2b6c65c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/guardians/{id}")]
+    public IActionResult DELETE_api_guardians__id__c9e1562c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/hl7/definition-fields/{id}")]
+    public IActionResult DELETE_api_hl7_definition_fields__id__f49d68c7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/hl7/definition-messages/{id}")]
+    public IActionResult DELETE_api_hl7_definition_messages__id__baab680d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/hl7/definition-segments/{id}")]
+    public IActionResult DELETE_api_hl7_definition_segments__id__0a77d85c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/hl7/definitions/{id}")]
+    public IActionResult DELETE_api_hl7_definitions__id__3c9772d0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/hl7/messages/{id}")]
+    public IActionResult DELETE_api_hl7_messages__id__b9267eb4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/images/{id}")]
+    public IActionResult DELETE_api_images__id__d9cf2324() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/imaging-devices/{id}")]
+    public IActionResult DELETE_api_imaging_devices__id__a1b6267e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/income-transfers/{id}")]
+    public IActionResult DELETE_api_income_transfers__id__8694ed62() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/installment-plans/{id}")]
+    public IActionResult DELETE_api_installment_plans__id__74204d43() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/insurance/categories/{id}")]
+    public IActionResult DELETE_api_insurance_categories__id__7acf5ae2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/insurance/filing-codes/{id}")]
+    public IActionResult DELETE_api_insurance_filing_codes__id__22f038a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/insurance/plans/{id}")]
+    public IActionResult DELETE_api_insurance_plans__id__3de38834() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/insurance/spans/{id}")]
+    public IActionResult DELETE_api_insurance_spans__id__c53426cc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/interventions/{id}")]
+    public IActionResult DELETE_api_interventions__id__a1b26d5e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/journal-entries/{id}")]
+    public IActionResult DELETE_api_journal_entries__id__060ee32b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/journalentries/{id}")]
+    public IActionResult DELETE_api_journalentries__id__73c8b3ef() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/measure-events/{id}")]
+    public IActionResult DELETE_api_measure_events__id__ca2a4bac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/medical-orders/{id}")]
+    public IActionResult DELETE_api_medical_orders__id__cf8933a6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/patient-list-elements/{id}")]
+    public IActionResult DELETE_api_patient_list_elements__id__d7fcb718() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/patient-popups/{id}")]
+    public IActionResult DELETE_api_patient_popups__id__0ceda37f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/patients/{id}/allergies/{allergyId}")]
+    public IActionResult DELETE_api_patients__id__allergies__allergyId__377d9d75() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/patients/{id}/forms/{formId}")]
+    public IActionResult DELETE_api_patients__id__forms__formId__ae486aed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/payor-types/{id}")]
+    public IActionResult DELETE_api_payor_types__id__5dfd1ace() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/payperiods/{id}")]
+    public IActionResult DELETE_api_payperiods__id__2f8f2300() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/payplan-charges/{id}")]
+    public IActionResult DELETE_api_payplan_charges__id__392a0b27() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/payplan-credits/{id}")]
+    public IActionResult DELETE_api_payplan_credits__id__1b81f844() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/payplan-templates/{id}")]
+    public IActionResult DELETE_api_payplan_templates__id__ca7f2bdb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/payplans/{id}")]
+    public IActionResult DELETE_api_payplans__id__7625f237() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/paysplits/{id}")]
+    public IActionResult DELETE_api_paysplits__id__c7fbe258() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/perio-exams/{id}")]
+    public IActionResult DELETE_api_perio_exams__id__699ae27e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/pharmacies/{id}")]
+    public IActionResult DELETE_api_pharmacies__id__b797a538() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/prepayments/{id}")]
+    public IActionResult DELETE_api_prepayments__id__312b5240() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/prescriptions/{id}")]
+    public IActionResult DELETE_api_prescriptions__id__cef66438() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/printers/{id}")]
+    public IActionResult DELETE_api_printers__id__94d6aac6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/proc-appt-colors/{id}")]
+    public IActionResult DELETE_api_proc_appt_colors__id__26cafa57() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/procedures/{id}")]
+    public IActionResult DELETE_api_procedures__id__aae7c77d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/requirements/{id}/field-conditions/{condId}")]
+    public IActionResult DELETE_api_requirements__id__field_conditions__condId__7bf21a38() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/requirements/{id}/students/{studentId}")]
+    public IActionResult DELETE_api_requirements__id__students__studentId__93b93b4d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/rx-alerts/{id}")]
+    public IActionResult DELETE_api_rx_alerts__id__b9b72422() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/schedule-blocks/{id}")]
+    public IActionResult DELETE_api_schedule_blocks__id__06d5f9e2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/scheduled-processes/{id}")]
+    public IActionResult DELETE_api_scheduled_processes__id__3f0f6acc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/schedules/{id}")]
+    public IActionResult DELETE_api_schedules__id__cc999ca5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/school-classes/{id}")]
+    public IActionResult DELETE_api_school_classes__id__7ae3f6dc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/screen-groups/{id}")]
+    public IActionResult DELETE_api_screen_groups__id__50a5dacd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/screens/{id}")]
+    public IActionResult DELETE_api_screens__id__f6149077() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/sheet-defs/{id}")]
+    public IActionResult DELETE_api_sheet_defs__id__47485e18() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/sheet-field-defs/{id}")]
+    public IActionResult DELETE_api_sheet_field_defs__id__22bed65e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/sig-button-defs/{id}")]
+    public IActionResult DELETE_api_sig_button_defs__id__0153c14f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/sig-element-defs/{id}")]
+    public IActionResult DELETE_api_sig_element_defs__id__842c6040() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/sms/messages/{id}")]
+    public IActionResult DELETE_api_sms_messages__id__b4446a8c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/state-abbreviations/{id}")]
+    public IActionResult DELETE_api_state_abbreviations__id__511a6441() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/statements")]
+    public IActionResult DELETE_api_statements_21beefb5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/summary-ccds/{id}")]
+    public IActionResult DELETE_api_summary_ccds__id__21638d56() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/suppliers/{id}")]
+    public IActionResult DELETE_api_suppliers__id__2d898827() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/supplies/{id}")]
+    public IActionResult DELETE_api_supplies__id__ead1aeb6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/supply-orders/{id}")]
+    public IActionResult DELETE_api_supply_orders__id__d7a51dbd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/supply-orders/{orderId}/items/{id}")]
+    public IActionResult DELETE_api_supply_orders__orderId__items__id__f83df75e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/task-lists/{id}")]
+    public IActionResult DELETE_api_task_lists__id__5bb91a03() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/task-lists/{id}/block")]
+    public IActionResult DELETE_api_task_lists__id__block_94075000() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/tasks/{id}")]
+    public IActionResult DELETE_api_tasks__id__7db37e31() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/tasks/{taskId}/attachments/{id}")]
+    public IActionResult DELETE_api_tasks__taskId__attachments__id__cafd036f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/tasks/{taskId}/notes/{id}")]
+    public IActionResult DELETE_api_tasks__taskId__notes__id__69618ff7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/tasks/{taskId}/subscribers/{userId}")]
+    public IActionResult DELETE_api_tasks__taskId__subscribers__userId__a53a0968() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/terminalactives")]
+    public IActionResult DELETE_api_terminalactives_aa7e6fde() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/terminalactives/{id}")]
+    public IActionResult DELETE_api_terminalactives__id__0cdb92f5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/text-messages/{id}")]
+    public IActionResult DELETE_api_text_messages__id__88f4a3d0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/timeadjusts/{id}")]
+    public IActionResult DELETE_api_timeadjusts__id__07c62643() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/timecardrules/{id}")]
+    public IActionResult DELETE_api_timecardrules__id__e2faec85() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/transactions/{id}")]
+    public IActionResult DELETE_api_transactions__id__8edebb4d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/translations/{id}")]
+    public IActionResult DELETE_api_translations__id__96642dfd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/treatment-plans/{id}")]
+    public IActionResult DELETE_api_treatment_plans__id__e49eced3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/web-mail/messages/{id}")]
+    public IActionResult DELETE_api_web_mail_messages__id__b2aad791() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/webchat/sessions/{id}/notes/{noteId}")]
+    public IActionResult DELETE_api_webchat_sessions__id__notes__noteId__bd1a2e58() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpDelete("/api/wiki/drafts/{id}")]
+    public IActionResult DELETE_api_wiki_drafts__id__a67b149b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/accounting-auto-pays")]
+    public IActionResult GET_api_accounting_auto_pays_caa26546() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/accounting-auto-pays/{id}")]
+    public IActionResult GET_api_accounting_auto_pays__id__21a42868() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/accounting/accounts")]
+    public IActionResult GET_api_accounting_accounts_5551fb52() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/accounts")]
+    public IActionResult GET_api_accounts_1350e4f5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/accounts/{accountNum}")]
+    public IActionResult GET_api_accounts__accountNum__a0eae360() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/accounts/{id}/balance")]
+    public IActionResult GET_api_accounts__id__balance_255dac39() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/addresses/{id}")]
+    public IActionResult GET_api_addresses__id__bb773b87() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/adjustment-types")]
+    public IActionResult GET_api_adjustment_types_21da7105() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/adjustments")]
+    public IActionResult GET_api_adjustments_33c3a44d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/adjustments")]
+    public IActionResult GET_api_adjustments_bc7dbb6e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/adjustments/{id}")]
+    public IActionResult GET_api_adjustments__id__2e8c8d31() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/advertising-postcards/accounts")]
+    public IActionResult GET_api_advertising_postcards_accounts_8289f76d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/advertising-postcards/sso")]
+    public IActionResult GET_api_advertising_postcards_sso_92fa5527() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ai/assistants")]
+    public IActionResult GET_api_ai_assistants_69cd0773() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/alert-categories")]
+    public IActionResult GET_api_alert_categories_20666849() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/alert-categories/{id}/links")]
+    public IActionResult GET_api_alert_categories__id__links_b966c146() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/alerts")]
+    public IActionResult GET_api_alerts_b4f1a7b2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/allergy-defs")]
+    public IActionResult GET_api_allergy_defs_b4500ec8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/allergy-defs/{id}")]
+    public IActionResult GET_api_allergy_defs__id__b0426af0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/allergydefs/{id}")]
+    public IActionResult GET_api_allergydefs__id__5c2b78ca() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthesia/med-suppliers")]
+    public IActionResult GET_api_anesthesia_med_suppliers_3ac05fc5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthesia/medications")]
+    public IActionResult GET_api_anesthesia_medications_1c2726d2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthesia/medications/{id}/quantity")]
+    public IActionResult GET_api_anesthesia_medications__id__quantity_4bb1d1ce() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthetic-records")]
+    public IActionResult GET_api_anesthetic_records_1155c21b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthetic-records/{id}/medications")]
+    public IActionResult GET_api_anesthetic_records__id__medications_94e1c23f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthetic-records/{id}/vitals")]
+    public IActionResult GET_api_anesthetic_records__id__vitals_021f89a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/anesthetic-records/{recordId}/score")]
+    public IActionResult GET_api_anesthetic_records__recordId__score_81495216() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/application/version")]
+    public IActionResult GET_api_application_version_c386fe2d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointment-types")]
+    public IActionResult GET_api_appointment_types_c6dce035() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments")]
+    public IActionResult GET_api_appointments_66a9777d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments")]
+    public IActionResult GET_api_appointments_d9483162() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/asap")]
+    public IActionResult GET_api_appointments_asap_0fa80870() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/confirm-list")]
+    public IActionResult GET_api_appointments_confirm_list_5cef9e17() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/plannedtracker")]
+    public IActionResult GET_api_appointments_plannedtracker_cea3a5a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/search")]
+    public IActionResult GET_api_appointments_search_91cc4ec1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/web-sched")]
+    public IActionResult GET_api_appointments_web_sched_e077d8fb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/{id}")]
+    public IActionResult GET_api_appointments__id__8d500e80() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appointments/{id}/tasks")]
+    public IActionResult GET_api_appointments__id__tasks_efc07f6f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appt-field-defs")]
+    public IActionResult GET_api_appt_field_defs_a6de8a2c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appt-reminder-rules/{id}")]
+    public IActionResult GET_api_appt_reminder_rules__id__7198b124() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appt-rules")]
+    public IActionResult GET_api_appt_rules_038e8ebd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appt-types")]
+    public IActionResult GET_api_appt_types_2ce6b102() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appt-types/{id}")]
+    public IActionResult GET_api_appt_types__id__0ae6647c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/appt-views")]
+    public IActionResult GET_api_appt_views_62622739() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ar-manager/patient-aging/excluded")]
+    public IActionResult GET_api_ar_manager_patient_aging_excluded_35db4c9c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ar-manager/patient-aging/sent")]
+    public IActionResult GET_api_ar_manager_patient_aging_sent_d3e4d56d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ar-manager/patient-aging/unsent")]
+    public IActionResult GET_api_ar_manager_patient_aging_unsent_9fdac126() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/asap-comms/history")]
+    public IActionResult GET_api_asap_comms_history_e47bf1d2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/asap-communications/history")]
+    public IActionResult GET_api_asap_communications_history_acc142cc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-code-conds")]
+    public IActionResult GET_api_auto_code_conds_2dca82c0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-code-items")]
+    public IActionResult GET_api_auto_code_items_1660d2ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-codes")]
+    public IActionResult GET_api_auto_codes_7fcb5e2f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-codes/{id}")]
+    public IActionResult GET_api_auto_codes__id__f02cf9bf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-comm-exclude-dates")]
+    public IActionResult GET_api_auto_comm_exclude_dates_94b2e2f7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-note-controls")]
+    public IActionResult GET_api_auto_note_controls_df44e91a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-notes")]
+    public IActionResult GET_api_auto_notes_61c6057d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/auto-notes/{id}")]
+    public IActionResult GET_api_auto_notes__id__a9402a1d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/automation-conditions/{id}")]
+    public IActionResult GET_api_automation_conditions__id__84f73210() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/automations")]
+    public IActionResult GET_api_automations_63614fb6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/automations/{id}")]
+    public IActionResult GET_api_automations__id__447d8663() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/automations/{id}/conditions")]
+    public IActionResult GET_api_automations__id__conditions_c2ad7ffe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/benefits/{id}")]
+    public IActionResult GET_api_benefits__id__df5fc922() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/blockouts/duplicates/count")]
+    public IActionResult GET_api_blockouts_duplicates_count_c145a41d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/bug-submission-hashes")]
+    public IActionResult GET_api_bug_submission_hashes_0e844486() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/bug-submissions")]
+    public IActionResult GET_api_bug_submissions_0d3e693d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/bug-submissions/diagnostics")]
+    public IActionResult GET_api_bug_submissions_diagnostics_2bd662a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/bug-submissions/{id}")]
+    public IActionResult GET_api_bug_submissions__id__e00b1160() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/bugs")]
+    public IActionResult GET_api_bugs_fc21ac3d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/bugs/{id}")]
+    public IActionResult GET_api_bugs__id__75413087() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/calendar")]
+    public IActionResult GET_api_calendar_00df728d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/canadian-networks")]
+    public IActionResult GET_api_canadian_networks_4a15eeef() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/canadiannetworks")]
+    public IActionResult GET_api_canadiannetworks_f52a2b77() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carecredit/sessions")]
+    public IActionResult GET_api_carecredit_sessions_ace1b9be() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carecredit/transactions")]
+    public IActionResult GET_api_carecredit_transactions_c36c04a0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers")]
+    public IActionResult GET_api_carriers_181f3746() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers")]
+    public IActionResult GET_api_carriers_689a85e1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers")]
+    public IActionResult GET_api_carriers_8cd74a7b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers")]
+    public IActionResult GET_api_carriers_b4466f41() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers")]
+    public IActionResult GET_api_carriers_ca2a210c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers/{id}")]
+    public IActionResult GET_api_carriers__id__253312d2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/carriers/{id}/dependent-plans")]
+    public IActionResult GET_api_carriers__id__dependent_plans_c43f095f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cds-triggers")]
+    public IActionResult GET_api_cds_triggers_69975b06() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cds/interventions")]
+    public IActionResult GET_api_cds_interventions_57dbe1da() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cds/permissions")]
+    public IActionResult GET_api_cds_permissions_be073cf7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cds/permissions/{userId}")]
+    public IActionResult GET_api_cds_permissions__userId__62bf5411() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/central-connections/computer-names")]
+    public IActionResult GET_api_central_connections_computer_names_7b161a6e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/central-connections/databases")]
+    public IActionResult GET_api_central_connections_databases_83c33979() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cert-employees")]
+    public IActionResult GET_api_cert_employees_04ecf1fb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cert-employees")]
+    public IActionResult GET_api_cert_employees_f3a75d54() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/certs")]
+    public IActionResult GET_api_certs_32a7c116() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/certs")]
+    public IActionResult GET_api_certs_b77ac718() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/certs/{id}")]
+    public IActionResult GET_api_certs__id__bd3b794f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/chart-views/filter")]
+    public IActionResult GET_api_chart_views_filter_6a28ae14() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/chart-views/{id}")]
+    public IActionResult GET_api_chart_views__id__79046a90() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/chart-views/{id}/display-fields")]
+    public IActionResult GET_api_chart_views__id__display_fields_d17d390c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-forms")]
+    public IActionResult GET_api_claim_forms_ea36a7bb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-forms/internal")]
+    public IActionResult GET_api_claim_forms_internal_c054c4aa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-forms/{id}")]
+    public IActionResult GET_api_claim_forms__id__5373d4f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-forms/{id}/items")]
+    public IActionResult GET_api_claim_forms__id__items_27567ef5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-pay-splits/outstanding")]
+    public IActionResult GET_api_claim_pay_splits_outstanding_e66c655c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-payments")]
+    public IActionResult GET_api_claim_payments_2024cde5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-payments/{id}")]
+    public IActionResult GET_api_claim_payments__id__f241370c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-payments/{id}/claims")]
+    public IActionResult GET_api_claim_payments__id__claims_45ea28ba() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-procs")]
+    public IActionResult GET_api_claim_procs_c77ecdde() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-procs/{id}")]
+    public IActionResult GET_api_claim_procs__id__ce23931b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claim-procs/{id}/bluebook-logs")]
+    public IActionResult GET_api_claim_procs__id__bluebook_logs_b1e65f98() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claimprocs")]
+    public IActionResult GET_api_claimprocs_3387c6f8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claims/history")]
+    public IActionResult GET_api_claims_history_b6aa8d42() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claims/queue")]
+    public IActionResult GET_api_claims_queue_5379e53b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claims/{id}")]
+    public IActionResult GET_api_claims__id__295699c8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claims/{id}/attachments")]
+    public IActionResult GET_api_claims__id__attachments_37bc692c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claims/{id}/claim-procs")]
+    public IActionResult GET_api_claims__id__claim_procs_399a0ae9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/claims/{id}/pay-splits")]
+    public IActionResult GET_api_claims__id__pay_splits_a67f1baf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clearinghouses")]
+    public IActionResult GET_api_clearinghouses_43365ae2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clearinghouses/default")]
+    public IActionResult GET_api_clearinghouses_default_363e8edc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clearinghouses/{id}")]
+    public IActionResult GET_api_clearinghouses__id__c9ebfc8e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinic-prefs")]
+    public IActionResult GET_api_clinic_prefs_e84844d6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinic-prefs/{clinicId}")]
+    public IActionResult GET_api_clinic_prefs__clinicId__9bf22db8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinic-prefs/{clinicId}/EConfirmExcludeDays")]
+    public IActionResult GET_api_clinic_prefs__clinicId__EConfirmExcludeDays_a6202d06() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinic-prefs/{clinicId}/EConfirmExcludeDaysUseHQ")]
+    public IActionResult GET_api_clinic_prefs__clinicId__EConfirmExcludeDaysUseHQ_c98e0fec() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinic-prefs/{clinicId}/{prefName}")]
+    public IActionResult GET_api_clinic_prefs__clinicId___prefName__2459396b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinics")]
+    public IActionResult GET_api_clinics_32a16909() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clinics/{id}")]
+    public IActionResult GET_api_clinics__id__cd1bdcae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clock-events/{id}")]
+    public IActionResult GET_api_clock_events__id__26c5686d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clockevents")]
+    public IActionResult GET_api_clockevents_a15ae97a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clockevents")]
+    public IActionResult GET_api_clockevents_d566faea() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/clockevents/timecardmanage")]
+    public IActionResult GET_api_clockevents_timecardmanage_4c18919f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cloud-users")]
+    public IActionResult GET_api_cloud_users_354c83d2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cloud-users/{id}")]
+    public IActionResult GET_api_cloud_users__id__57eef398() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cloud/accounts")]
+    public IActionResult GET_api_cloud_accounts_319fa233() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cloud/accounts/{id}/session-limit")]
+    public IActionResult GET_api_cloud_accounts__id__session_limit_f2e7b595() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cloud/sessions")]
+    public IActionResult GET_api_cloud_sessions_d17a341a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/code-groups")]
+    public IActionResult GET_api_code_groups_1b245e8b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/code-groups/{id}")]
+    public IActionResult GET_api_code_groups__id__1e579068() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/codes/value-sets/{oid}")]
+    public IActionResult GET_api_codes_value_sets__oid__821fb1ca() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/communication-preferences")]
+    public IActionResult GET_api_communication_preferences_f3bafa0c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/computerprefs")]
+    public IActionResult GET_api_computerprefs_81c37aef() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/computers")]
+    public IActionResult GET_api_computers_88230a72() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/computers/service-info")]
+    public IActionResult GET_api_computers_service_info_9ea5fbc7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/connections/status")]
+    public IActionResult GET_api_connections_status_ad2d0214() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/contacts")]
+    public IActionResult GET_api_contacts_21698ca1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/contacts/{id}")]
+    public IActionResult GET_api_contacts__id__e1cdf044() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/counties")]
+    public IActionResult GET_api_counties_72cbaadf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/covcats")]
+    public IActionResult GET_api_covcats_cc59f3ff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cpts")]
+    public IActionResult GET_api_cpts_db56e243() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/credit-cards/tokens")]
+    public IActionResult GET_api_credit_cards_tokens_aa4aadf7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/credit-cards/{id}")]
+    public IActionResult GET_api_credit_cards__id__3b674b87() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/credit-recurring-charges")]
+    public IActionResult GET_api_credit_recurring_charges_5cd73132() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/credit-recurring-charges/dates")]
+    public IActionResult GET_api_credit_recurring_charges_dates_7ce0c58d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cvxs")]
+    public IActionResult GET_api_cvxs_af702c80() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/cvxs/{code}")]
+    public IActionResult GET_api_cvxs__code__104e8d1a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database-maintenance/database-names")]
+    public IActionResult GET_api_database_maintenance_database_names_a774a996() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database-maintenance/duplicate-claim-procs")]
+    public IActionResult GET_api_database_maintenance_duplicate_claim_procs_b186efa3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database-maintenance/duplicate-supplemental-payments")]
+    public IActionResult GET_api_database_maintenance_duplicate_supplemental_payments_9780ffa2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database-maintenance/methods")]
+    public IActionResult GET_api_database_maintenance_methods_2ad6b788() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database-maintenance/missing-claim-procs")]
+    public IActionResult GET_api_database_maintenance_missing_claim_procs_e565e46d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database-maintenance/patient-methods")]
+    public IActionResult GET_api_database_maintenance_patient_methods_fff24ad8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database/indexes/redundant")]
+    public IActionResult GET_api_database_indexes_redundant_e3a58128() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/database/innodb")]
+    public IActionResult GET_api_database_innodb_87134b13() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_022dcf84() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_2c69b85d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_3f18f5ed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_477fc6d6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_5381175b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_55830e05() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_5d1a83ff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_684cb1c2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_729905f9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_8146924a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_9b2bf8ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_a02c4ca0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_a03b7fe1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_b0562f33() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions")]
+    public IActionResult GET_api_definitions_efc8b552() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions/billing-types")]
+    public IActionResult GET_api_definitions_billing_types_ecd4bec0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions/pay-split-unearned-types")]
+    public IActionResult GET_api_definitions_pay_split_unearned_types_695227f4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/definitions/{id}")]
+    public IActionResult GET_api_definitions__id__f5bfbe7e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs")]
+    public IActionResult GET_api_defs_82fc782b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs")]
+    public IActionResult GET_api_defs_a42a8519() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs")]
+    public IActionResult GET_api_defs_c854b70a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs/adj-types")]
+    public IActionResult GET_api_defs_adj_types_5d02228e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs/billing-types")]
+    public IActionResult GET_api_defs_billing_types_87020cd5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs/comm-log-types")]
+    public IActionResult GET_api_defs_comm_log_types_d53975fe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/defs/payment-types")]
+    public IActionResult GET_api_defs_payment_types_a9c2c591() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/deposits")]
+    public IActionResult GET_api_deposits_6061df99() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/deposits/{depositNum}")]
+    public IActionResult GET_api_deposits__depositNum__51140d69() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/deposits/{id}")]
+    public IActionResult GET_api_deposits__id__0ffa431a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/discount-plan-subs/{id}")]
+    public IActionResult GET_api_discount_plan_subs__id__fe2386b3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/discount-plans")]
+    public IActionResult GET_api_discount_plans_0ce51d01() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/discount-plans/{id}")]
+    public IActionResult GET_api_discount_plans__id__f88386c8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/discount-plans/{id}/patients")]
+    public IActionResult GET_api_discount_plans__id__patients_9e9acfb9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/discount-plans/{id}/patients/count")]
+    public IActionResult GET_api_discount_plans__id__patients_count_71c23048() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/disease-defs")]
+    public IActionResult GET_api_disease_defs_9d0b6f3e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/diseasedefs/{id}")]
+    public IActionResult GET_api_diseasedefs__id__8154fa0b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/display-field-categories")]
+    public IActionResult GET_api_display_field_categories_98bc6e46() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/display-fields")]
+    public IActionResult GET_api_display_fields_c2f3c0ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/display-fields/ortho")]
+    public IActionResult GET_api_display_fields_ortho_a87b6a53() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/domain-users")]
+    public IActionResult GET_api_domain_users_da17f0f3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/drug-manufacturers")]
+    public IActionResult GET_api_drug_manufacturers_c27d797e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/drug-units")]
+    public IActionResult GET_api_drug_units_6220fa85() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/dunning-messages")]
+    public IActionResult GET_api_dunning_messages_1917b02b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/dunnings")]
+    public IActionResult GET_api_dunnings_2f87dcd2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ebills")]
+    public IActionResult GET_api_ebills_aa979646() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eclipboards/definitions")]
+    public IActionResult GET_api_eclipboards_definitions_1c0b95da() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eclipboards/imagecapturedefs")]
+    public IActionResult GET_api_eclipboards_imagecapturedefs_6b7b962c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eclipboards/imagecapturedefs/{id}")]
+    public IActionResult GET_api_eclipboards_imagecapturedefs__id__53e010dc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eclipboards/images")]
+    public IActionResult GET_api_eclipboards_images_2938ee60() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eclipboards/sheetrules")]
+    public IActionResult GET_api_eclipboards_sheetrules_18c78477() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eclipboards/sheetrules/{id}")]
+    public IActionResult GET_api_eclipboards_sheetrules__id__cc2c20e4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/edu-resources")]
+    public IActionResult GET_api_edu_resources_47942098() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/edu-resources/{id}")]
+    public IActionResult GET_api_edu_resources__id__5f918493() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/education-resources/patients/{id}")]
+    public IActionResult GET_api_education_resources_patients__id__555d13b9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/amendments")]
+    public IActionResult GET_api_ehr_amendments_50773236() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/amendments/{id}")]
+    public IActionResult GET_api_ehr_amendments__id__69394546() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/apt-observations")]
+    public IActionResult GET_api_ehr_apt_observations_70ca8af8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/care-plans")]
+    public IActionResult GET_api_ehr_care_plans_6c251689() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/ccd/electronic-copy")]
+    public IActionResult GET_api_ehr_ccd_electronic_copy_f4e539c0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/education-resources")]
+    public IActionResult GET_api_ehr_education_resources_27e963b6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-notes/{id}")]
+    public IActionResult GET_api_ehr_lab_notes__id__03103ff3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-panels")]
+    public IActionResult GET_api_ehr_lab_panels_8bad3df2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-panels/{id}")]
+    public IActionResult GET_api_ehr_lab_panels__id__912f2ab2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-results")]
+    public IActionResult GET_api_ehr_lab_results_969f5c3f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-results")]
+    public IActionResult GET_api_ehr_lab_results_d297243f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-results/{id}")]
+    public IActionResult GET_api_ehr_lab_results__id__f66b34c5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/lab-specimens/{id}")]
+    public IActionResult GET_api_ehr_lab_specimens__id__0bf1806d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/labs")]
+    public IActionResult GET_api_ehr_labs_4d8a2a29() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/labs/{id}")]
+    public IActionResult GET_api_ehr_labs__id__d83dd5c9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/labs/{labId}/images")]
+    public IActionResult GET_api_ehr_labs__labId__images_fd7935dd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/not-performed")]
+    public IActionResult GET_api_ehr_not_performed_3edb264b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/not-performed/{id}")]
+    public IActionResult GET_api_ehr_not_performed__id__ad34962b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/patients/{id}")]
+    public IActionResult GET_api_ehr_patients__id__7e074142() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/provider-keys")]
+    public IActionResult GET_api_ehr_provider_keys_4524297b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/quality-measures")]
+    public IActionResult GET_api_ehr_quality_measures_0de1f1b7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/quality-measures")]
+    public IActionResult GET_api_ehr_quality_measures_c8861e33() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/quality-measures/{id}")]
+    public IActionResult GET_api_ehr_quality_measures__id__10b0d1a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/quality-measures/{id}")]
+    public IActionResult GET_api_ehr_quality_measures__id__4b18a0ed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/quarterly-keys/{id}")]
+    public IActionResult GET_api_ehr_quarterly_keys__id__f2c7f91e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/vaccine-defs")]
+    public IActionResult GET_api_ehr_vaccine_defs_357475a0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ehr/vaccines")]
+    public IActionResult GET_api_ehr_vaccines_5df6bcf2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/elect-ids")]
+    public IActionResult GET_api_elect_ids_8a080b6e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/elect-ids/{id}")]
+    public IActionResult GET_api_elect_ids__id__b4c7e7f9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eligibilities/responses/{id}")]
+    public IActionResult GET_api_eligibilities_responses__id__81e36d53() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-addresses")]
+    public IActionResult GET_api_email_addresses_e048b8a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-addresses/notify")]
+    public IActionResult GET_api_email_addresses_notify_6e98fae9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-addresses/{id}")]
+    public IActionResult GET_api_email_addresses__id__e6e294fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-autographs/{id}")]
+    public IActionResult GET_api_email_autographs__id__d5a6f6a6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-hosting/signatures")]
+    public IActionResult GET_api_email_hosting_signatures_5e8a5ed2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-messages/inbox")]
+    public IActionResult GET_api_email_messages_inbox_bbc78541() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-messages/{id}")]
+    public IActionResult GET_api_email_messages__id__e984832b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/email-templates/{id}")]
+    public IActionResult GET_api_email_templates__id__c8ceda16() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employee-time/graph")]
+    public IActionResult GET_api_employee_time_graph_a3279062() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employee-time/view")]
+    public IActionResult GET_api_employee_time_view_ddaf35be() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employees")]
+    public IActionResult GET_api_employees_cde2f945() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employees")]
+    public IActionResult GET_api_employees_f9351841() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employees/{id}")]
+    public IActionResult GET_api_employees__id__aab0d5c6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employers")]
+    public IActionResult GET_api_employers_06c15379() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/employers/{id}")]
+    public IActionResult GET_api_employers__id__2014c5d8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/encounters")]
+    public IActionResult GET_api_encounters_b339af6a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/encounters/{id}")]
+    public IActionResult GET_api_encounters__id__3163aeb7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/equipment")]
+    public IActionResult GET_api_equipment_1b2a6309() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/equipment/{id}")]
+    public IActionResult GET_api_equipment__id__7cbd7579() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eras/auto-processed")]
+    public IActionResult GET_api_eras_auto_processed_e0cf0f74() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eroutingdefs")]
+    public IActionResult GET_api_eroutingdefs_d3de8777() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eroutingdefs/{id}")]
+    public IActionResult GET_api_eroutingdefs__id__c1676c59() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eroutings")]
+    public IActionResult GET_api_eroutings_43176d12() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservice-actions")]
+    public IActionResult GET_api_eservice_actions_1808bce3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservice-logs")]
+    public IActionResult GET_api_eservice_logs_e04a50ef() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/automessages")]
+    public IActionResult GET_api_eservices_automessages_41bc4382() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/automessages/advanced")]
+    public IActionResult GET_api_eservices_automessages_advanced_55a482b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/automessages/preferences")]
+    public IActionResult GET_api_eservices_automessages_preferences_d0df805a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/eclipboard/settings")]
+    public IActionResult GET_api_eservices_eclipboard_settings_7c3d8752() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/econnector/status")]
+    public IActionResult GET_api_eservices_econnector_status_1868fef9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/mobile/settings")]
+    public IActionResult GET_api_eservices_mobile_settings_ac8c1dd4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/mobileapp/devices")]
+    public IActionResult GET_api_eservices_mobileapp_devices_db2715f4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/mobileweb/settings")]
+    public IActionResult GET_api_eservices_mobileweb_settings_3c1e51fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/payment-portal")]
+    public IActionResult GET_api_eservices_payment_portal_2e699ac7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/preferences")]
+    public IActionResult GET_api_eservices_preferences_8868d2a0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/setup")]
+    public IActionResult GET_api_eservices_setup_0e2b9634() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/signups")]
+    public IActionResult GET_api_eservices_signups_5bef1ddd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/signups")]
+    public IActionResult GET_api_eservices_signups_a2a5f980() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/texting/usage")]
+    public IActionResult GET_api_eservices_texting_usage_34ba9d50() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/websched-asap/clinics")]
+    public IActionResult GET_api_eservices_websched_asap_clinics_42ea8deb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/eservices/websched/hostedurls")]
+    public IActionResult GET_api_eservices_websched_hostedurls_9091ab17() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/270")]
+    public IActionResult GET_api_etrans_270_dd3eb5b9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/270/{id}")]
+    public IActionResult GET_api_etrans_270__id__9cc9a255() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/270/{id}/raw")]
+    public IActionResult GET_api_etrans_270__id__raw_205e97c7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/277/{id}")]
+    public IActionResult GET_api_etrans_277__id__b42cb597() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835")]
+    public IActionResult GET_api_etrans_835_1709e3b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835/claims")]
+    public IActionResult GET_api_etrans_835_claims_2c1d81d1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835/claims/{id}")]
+    public IActionResult GET_api_etrans_835_claims__id__cec511a0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835/eobs")]
+    public IActionResult GET_api_etrans_835_eobs_59a37313() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835/eras")]
+    public IActionResult GET_api_etrans_835_eras_7de9242c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835/procedures/{id}")]
+    public IActionResult GET_api_etrans_835_procedures__id__5583b9b9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/835/{id}")]
+    public IActionResult GET_api_etrans_835__id__38d69f44() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/{id}")]
+    public IActionResult GET_api_etrans__id__5961fd54() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/etrans/{id}/message-text")]
+    public IActionResult GET_api_etrans__id__message_text_e681052f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/evaluation-criterion-defs/{id}")]
+    public IActionResult GET_api_evaluation_criterion_defs__id__2b234570() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/evaluation-defs")]
+    public IActionResult GET_api_evaluation_defs_75d5fbd0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/evaluation-defs/{id}")]
+    public IActionResult GET_api_evaluation_defs__id__dd413c88() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/evaluations")]
+    public IActionResult GET_api_evaluations_17541133() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/evaluations/report")]
+    public IActionResult GET_api_evaluations_report_47e3fbf1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/evaluations/{id}")]
+    public IActionResult GET_api_evaluations__id__8ee5140d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/exam-sheets")]
+    public IActionResult GET_api_exam_sheets_311b1945() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/families/{id}/balance")]
+    public IActionResult GET_api_families__id__balance_b9034606() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/feature-requests")]
+    public IActionResult GET_api_feature_requests_82d6421a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedule-groups")]
+    public IActionResult GET_api_fee_schedule_groups_9327cd14() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedule-groups/{id}")]
+    public IActionResult GET_api_fee_schedule_groups__id__da3506d9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedules")]
+    public IActionResult GET_api_fee_schedules_7d97e3be() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedules/insurance")]
+    public IActionResult GET_api_fee_schedules_insurance_a6a41c3e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedules/ontario")]
+    public IActionResult GET_api_fee_schedules_ontario_09c17410() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedules/remote")]
+    public IActionResult GET_api_fee_schedules_remote_5912410e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fee-schedules/{id}")]
+    public IActionResult GET_api_fee_schedules__id__01913ee2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fees/{id}")]
+    public IActionResult GET_api_fees__id__ebb566c6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fhir/api-keys")]
+    public IActionResult GET_api_fhir_api_keys_5837de4b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/fhir/settings")]
+    public IActionResult GET_api_fhir_settings_f3b4a29a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/field-def-links")]
+    public IActionResult GET_api_field_def_links_0ed65167() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/files")]
+    public IActionResult GET_api_files_e66cb289() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/finance-charges")]
+    public IActionResult GET_api_finance_charges_66e033d7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/grading-scales")]
+    public IActionResult GET_api_grading_scales_ca30324f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/grading-scales/{id}")]
+    public IActionResult GET_api_grading_scales__id__2f65741e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/graphics/settings")]
+    public IActionResult GET_api_graphics_settings_040820ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/grid-selection")]
+    public IActionResult GET_api_grid_selection_637a03dd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/group-permissions")]
+    public IActionResult GET_api_group_permissions_5a9b0a22() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hcpcs")]
+    public IActionResult GET_api_hcpcs_89e1d2df() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hie/settings")]
+    public IActionResult GET_api_hie_settings_8d95f1fb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/definition-fields/{id}")]
+    public IActionResult GET_api_hl7_definition_fields__id__683d5a6f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/definition-messages/{id}")]
+    public IActionResult GET_api_hl7_definition_messages__id__e12b39c1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/definition-segments/{id}")]
+    public IActionResult GET_api_hl7_definition_segments__id__d1df65b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/definitions")]
+    public IActionResult GET_api_hl7_definitions_289c3b70() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/definitions/{id}")]
+    public IActionResult GET_api_hl7_definitions__id__7aa5af4e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/messages")]
+    public IActionResult GET_api_hl7_messages_52e7b055() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/hl7/messages/{id}")]
+    public IActionResult GET_api_hl7_messages__id__6f0d3921() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/icd10")]
+    public IActionResult GET_api_icd10_5a86fbac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/icd10/{code}")]
+    public IActionResult GET_api_icd10__code__a79f400c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/icd9")]
+    public IActionResult GET_api_icd9_31269f55() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/icd9/{code}")]
+    public IActionResult GET_api_icd9__code__672241a8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/images")]
+    public IActionResult GET_api_images_3b6a4f5a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/images/dxc")]
+    public IActionResult GET_api_images_dxc_b69477bb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/images/select")]
+    public IActionResult GET_api_images_select_681ae63d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/imaging-devices")]
+    public IActionResult GET_api_imaging_devices_29139127() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/imaging-devices/{id}")]
+    public IActionResult GET_api_imaging_devices__id__11df2e05() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/imaging/settings")]
+    public IActionResult GET_api_imaging_settings_908afc4e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/income-transfers")]
+    public IActionResult GET_api_income_transfers_c8e50141() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/infobutton")]
+    public IActionResult GET_api_infobutton_5dfc6397() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ins-filing-codes")]
+    public IActionResult GET_api_ins_filing_codes_52cd50c5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ins-plans")]
+    public IActionResult GET_api_ins_plans_7214fa43() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ins-plans/{id}")]
+    public IActionResult GET_api_ins_plans__id__ca149b29() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insplans/{id}")]
+    public IActionResult GET_api_insplans__id__5c409343() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/inssubs")]
+    public IActionResult GET_api_inssubs_9651e82b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/inssubs/{id}")]
+    public IActionResult GET_api_inssubs__id__f701f9ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/installment-plans/{id}")]
+    public IActionResult GET_api_installment_plans__id__458eaf0b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance-plans/{id}")]
+    public IActionResult GET_api_insurance_plans__id__c820bede() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/adjustments")]
+    public IActionResult GET_api_insurance_adjustments_deeed199() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/categories")]
+    public IActionResult GET_api_insurance_categories_d1866c4b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/categories/{id}")]
+    public IActionResult GET_api_insurance_categories__id__8568b9ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/edit-logs")]
+    public IActionResult GET_api_insurance_edit_logs_2c3ba188() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/filing-codes")]
+    public IActionResult GET_api_insurance_filing_codes_ab136a52() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/filing-codes/{id}")]
+    public IActionResult GET_api_insurance_filing_codes__id__b4cb4304() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/history-settings")]
+    public IActionResult GET_api_insurance_history_settings_a11d393d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/patient-logs")]
+    public IActionResult GET_api_insurance_patient_logs_52120cfd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/plans")]
+    public IActionResult GET_api_insurance_plans_aa7bbc59() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/plans/family")]
+    public IActionResult GET_api_insurance_plans_family_42018efc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/plans/substitution")]
+    public IActionResult GET_api_insurance_plans_substitution_afbe28a2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/plans/{id}")]
+    public IActionResult GET_api_insurance_plans__id__8ec5985f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/plans/{id}/overrides")]
+    public IActionResult GET_api_insurance_plans__id__overrides_23809cbb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/remaining")]
+    public IActionResult GET_api_insurance_remaining_51649ac3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/spans/{id}")]
+    public IActionResult GET_api_insurance_spans__id__98b190f7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/verification")]
+    public IActionResult GET_api_insurance_verification_e45251ca() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/insurance/verification/settings")]
+    public IActionResult GET_api_insurance_verification_settings_17aa3190() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/interventions")]
+    public IActionResult GET_api_interventions_aa32c470() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/interventions/{id}")]
+    public IActionResult GET_api_interventions__id__f8e3eb05() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/invoices/items")]
+    public IActionResult GET_api_invoices_items_94bd0eea() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/job-links")]
+    public IActionResult GET_api_job_links_75913bb7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/journal-entries")]
+    public IActionResult GET_api_journal_entries_6f4c60bf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/journal-entries/{id}")]
+    public IActionResult GET_api_journal_entries__id__4cfc55af() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/journalentries")]
+    public IActionResult GET_api_journalentries_1413b37c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/knowledge-requests")]
+    public IActionResult GET_api_knowledge_requests_01993cc1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/lab-cases")]
+    public IActionResult GET_api_lab_cases_f6725ad6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/lab-cases/{id}")]
+    public IActionResult GET_api_lab_cases__id__e81c70e4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/lab-panels")]
+    public IActionResult GET_api_lab_panels_4aede780() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/lab-results")]
+    public IActionResult GET_api_lab_results_5bb6757b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/lab-turnarounds/{id}")]
+    public IActionResult GET_api_lab_turnarounds__id__d0f3b542() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/laboratories")]
+    public IActionResult GET_api_laboratories_7f52024d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/laboratories/{id}")]
+    public IActionResult GET_api_laboratories__id__58022343() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/languages")]
+    public IActionResult GET_api_languages_b4ef4151() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/languages/definitions")]
+    public IActionResult GET_api_languages_definitions_e4acc793() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/letters")]
+    public IActionResult GET_api_letters_4feee510() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/letters/merges")]
+    public IActionResult GET_api_letters_merges_54b9ba02() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/letters/merges/{id}")]
+    public IActionResult GET_api_letters_merges__id__f5e480ad() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/letters/templates/{id}")]
+    public IActionResult GET_api_letters_templates__id__a60ae06b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/license")]
+    public IActionResult GET_api_license_b5135544() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/loinc")]
+    public IActionResult GET_api_loinc_e4a3629c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/loincs")]
+    public IActionResult GET_api_loincs_a7df55e5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/loincs/{code}")]
+    public IActionResult GET_api_loincs__code__23905943() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/map-areas/{id}")]
+    public IActionResult GET_api_map_areas__id__fe772dd3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/markup-tables/{id}")]
+    public IActionResult GET_api_markup_tables__id__d947e53c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/analytics")]
+    public IActionResult GET_api_mass_email_analytics_4f0bfb44() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/birthdays")]
+    public IActionResult GET_api_mass_email_birthdays_ddae46cb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/examples")]
+    public IActionResult GET_api_mass_email_examples_31012055() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/results")]
+    public IActionResult GET_api_mass_email_results_129e5d75() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/settings")]
+    public IActionResult GET_api_mass_email_settings_07d2dd92() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/templates")]
+    public IActionResult GET_api_mass_email_templates_bed5300e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mass-email/templates/{id}")]
+    public IActionResult GET_api_mass_email_templates__id__17aa7ffe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/measure-events")]
+    public IActionResult GET_api_measure_events_10a945cb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/measure-events")]
+    public IActionResult GET_api_measure_events_30a7fa49() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/measure-events")]
+    public IActionResult GET_api_measure_events_72e97076() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/measure-events")]
+    public IActionResult GET_api_measure_events_9a3fc3db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/measure-events")]
+    public IActionResult GET_api_measure_events_d7399e8f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/measure-events/{id}")]
+    public IActionResult GET_api_measure_events__id__a86acbf3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/med-labs")]
+    public IActionResult GET_api_med_labs_b8423adc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/med-labs/{id}")]
+    public IActionResult GET_api_med_labs__id__89a0b76e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/med-labs/{id}/hl7")]
+    public IActionResult GET_api_med_labs__id__hl7_87083e37() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/med-labs/{id}/results")]
+    public IActionResult GET_api_med_labs__id__results_6ec8309a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/medical-orders")]
+    public IActionResult GET_api_medical_orders_4d0fdc1e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/medical-orders/{id}")]
+    public IActionResult GET_api_medical_orders__id__d8928eb5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/medications")]
+    public IActionResult GET_api_medications_0f7f5e21() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/medications/{id}")]
+    public IActionResult GET_api_medications__id__a1288d12() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/messages/pay/{id}")]
+    public IActionResult GET_api_messages_pay__id__45c13dc2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/messages/replacements/{id}")]
+    public IActionResult GET_api_messages_replacements__id__f537a3de() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/messaging/buttons")]
+    public IActionResult GET_api_messaging_buttons_c343f961() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/messaging/settings")]
+    public IActionResult GET_api_messaging_settings_c92c7d1d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/misc/now")]
+    public IActionResult GET_api_misc_now_29b497e0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/misc/version")]
+    public IActionResult GET_api_misc_version_5004a693() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mobile/branding/{id}")]
+    public IActionResult GET_api_mobile_branding__id__03e1d19f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mobileappdevices")]
+    public IActionResult GET_api_mobileappdevices_0e4d7ac5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/mountainside")]
+    public IActionResult GET_api_mountainside_fcfc81fb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/multi-visit-groups")]
+    public IActionResult GET_api_multi_visit_groups_3d23ba07() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/newcrop/billing")]
+    public IActionResult GET_api_newcrop_billing_26cae50b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/notes/templates")]
+    public IActionResult GET_api_notes_templates_c2d71e27() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/odtouch/security")]
+    public IActionResult GET_api_odtouch_security_ec9ab587() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/oid-registry")]
+    public IActionResult GET_api_oid_registry_b0d3f6e5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/online-payments")]
+    public IActionResult GET_api_online_payments_4a088e24() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/operatories")]
+    public IActionResult GET_api_operatories_8d3e5271() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/operatories/{id}")]
+    public IActionResult GET_api_operatories__id__098a6b43() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/cases/{id}")]
+    public IActionResult GET_api_ortho_cases__id__28d12498() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/charts/settings")]
+    public IActionResult GET_api_ortho_charts_settings_52639719() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/charts/{id}")]
+    public IActionResult GET_api_ortho_charts__id__be50b94d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/hardware/specs")]
+    public IActionResult GET_api_ortho_hardware_specs_af5bde85() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/hardware/specs/{id}")]
+    public IActionResult GET_api_ortho_hardware_specs__id__0eb5b3bc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/hardware/{id}")]
+    public IActionResult GET_api_ortho_hardware__id__4f6797ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/patients/{id}")]
+    public IActionResult GET_api_ortho_patients__id__14d32691() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/rx")]
+    public IActionResult GET_api_ortho_rx_146af0f6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ortho/rx/{id}")]
+    public IActionResult GET_api_ortho_rx__id__6d8222d4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/pat-field-defs")]
+    public IActionResult GET_api_pat_field_defs_3013193c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patfielddefs")]
+    public IActionResult GET_api_patfielddefs_cb386769() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patfielddefs/carecredit")]
+    public IActionResult GET_api_patfielddefs_carecredit_81a6a175() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-field-defs")]
+    public IActionResult GET_api_patient_field_defs_90719be4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-field-defs/{id}")]
+    public IActionResult GET_api_patient_field_defs__id__8b2cc6f9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-fields/{id}")]
+    public IActionResult GET_api_patient_fields__id__41ed78b2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-list-elements/{id}")]
+    public IActionResult GET_api_patient_list_elements__id__81aef517() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-lists")]
+    public IActionResult GET_api_patient_lists_8b7d4309() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-lists/ehr")]
+    public IActionResult GET_api_patient_lists_ehr_5e36bfcb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-lists/ehr/elements/{id}")]
+    public IActionResult GET_api_patient_lists_ehr_elements__id__8ef9f68f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-lists/ehr/results")]
+    public IActionResult GET_api_patient_lists_ehr_results_06c5be11() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-lists/elements/{id}")]
+    public IActionResult GET_api_patient_lists_elements__id__b5781e62() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patient-lists/results")]
+    public IActionResult GET_api_patient_lists_results_9e88f4f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients")]
+    public IActionResult GET_api_patients_a7b0c2e2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients")]
+    public IActionResult GET_api_patients_b24b58b3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/communications")]
+    public IActionResult GET_api_patients_communications_109ea701() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}")]
+    public IActionResult GET_api_patients__id__7d48f031() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/appointments")]
+    public IActionResult GET_api_patients__id__appointments_de356517() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/ccd")]
+    public IActionResult GET_api_patients__id__ccd_bb34b3ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/credit-cards")]
+    public IActionResult GET_api_patients__id__credit_cards_ee08dd86() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/documents")]
+    public IActionResult GET_api_patients__id__documents_4e152d07() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/family")]
+    public IActionResult GET_api_patients__id__family_b5e329a4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/family-phi")]
+    public IActionResult GET_api_patients__id__family_phi_b8035552() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/medical")]
+    public IActionResult GET_api_patients__id__medical_eed22d6e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/medications")]
+    public IActionResult GET_api_patients__id__medications_859a868b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/pat-plans")]
+    public IActionResult GET_api_patients__id__pat_plans_e3cd8878() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/patfields")]
+    public IActionResult GET_api_patients__id__patfields_05765cab() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/plans")]
+    public IActionResult GET_api_patients__id__plans_42fcea72() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/popups")]
+    public IActionResult GET_api_patients__id__popups_06c8e81c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/prescriptions")]
+    public IActionResult GET_api_patients__id__prescriptions_a30655ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/procedures")]
+    public IActionResult GET_api_patients__id__procedures_c0c160a8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{id}/recalls")]
+    public IActionResult GET_api_patients__id__recalls_20a58109() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/patients/{patNum}")]
+    public IActionResult GET_api_patients__patNum__faba73e6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payments")]
+    public IActionResult GET_api_payments_34f78d75() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payments/{id}")]
+    public IActionResult GET_api_payments__id__9a85bb26() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payments/{payNum}")]
+    public IActionResult GET_api_payments__payNum__1d4018aa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payor-types")]
+    public IActionResult GET_api_payor_types_bab9a793() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payor-types/{id}")]
+    public IActionResult GET_api_payor_types__id__23987588() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payperiods")]
+    public IActionResult GET_api_payperiods_0484384f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payperiods")]
+    public IActionResult GET_api_payperiods_514eceed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payperiods/{id}")]
+    public IActionResult GET_api_payperiods__id__cc64b070() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplan-charges")]
+    public IActionResult GET_api_payplan_charges_d70b0bf0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplan-charges/{id}")]
+    public IActionResult GET_api_payplan_charges__id__61fde652() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplan-credits")]
+    public IActionResult GET_api_payplan_credits_8a1f7bc8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplan-templates")]
+    public IActionResult GET_api_payplan_templates_04d2c975() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplan-templates/{id}")]
+    public IActionResult GET_api_payplan_templates__id__f38c78cb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplans")]
+    public IActionResult GET_api_payplans_e5b8b750() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplans/{id}")]
+    public IActionResult GET_api_payplans__id__21fb601a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payplans/{id}/dynamic")]
+    public IActionResult GET_api_payplans__id__dynamic_1db19cf0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/paysplits")]
+    public IActionResult GET_api_paysplits_4f2945cb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/paysplits/{id}")]
+    public IActionResult GET_api_paysplits__id__99911c3a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/payterminals/{id}")]
+    public IActionResult GET_api_payterminals__id__d5d2386d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/perio-exams/{id}")]
+    public IActionResult GET_api_perio_exams__id__c3fffe20() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/perio-exams/{id}/graph")]
+    public IActionResult GET_api_perio_exams__id__graph_0416c244() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/permissions/groups/{id}")]
+    public IActionResult GET_api_permissions_groups__id__6f7eef0c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/pharmacies")]
+    public IActionResult GET_api_pharmacies_312714b9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/pharmacies/{id}")]
+    public IActionResult GET_api_pharmacies__id__d134896b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/phone-numbers")]
+    public IActionResult GET_api_phone_numbers_0f9ca9ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/practice")]
+    public IActionResult GET_api_practice_cce3061f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_0ad665ff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_11f14e5f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_339e00f0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_64a5cf73() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_70ac7c80() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_a17d9514() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_b9f27d56() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_db818b5f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences")]
+    public IActionResult GET_api_preferences_ec782f69() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/DefaultCCProcs")]
+    public IActionResult GET_api_preferences_DefaultCCProcs_51450725() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/PracticeBankNumber")]
+    public IActionResult GET_api_preferences_PracticeBankNumber_5e18b1a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/PracticeDefaultProv")]
+    public IActionResult GET_api_preferences_PracticeDefaultProv_88f40faf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/SoftwareName")]
+    public IActionResult GET_api_preferences_SoftwareName_1222a366() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/TaskAttachmentCategory")]
+    public IActionResult GET_api_preferences_TaskAttachmentCategory_d2de5806() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/confirmation")]
+    public IActionResult GET_api_preferences_confirmation_79049776() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/features")]
+    public IActionResult GET_api_preferences_features_6df80ea6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/language")]
+    public IActionResult GET_api_preferences_language_e55c74ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/path")]
+    public IActionResult GET_api_preferences_path_7279871e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/payment-plan-options")]
+    public IActionResult GET_api_preferences_payment_plan_options_d69b3fa1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/perio")]
+    public IActionResult GET_api_preferences_perio_1502014e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/perio-graphical")]
+    public IActionResult GET_api_preferences_perio_graphical_621611e2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/perio-voice")]
+    public IActionResult GET_api_preferences_perio_voice_b4383bf4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/storecctokens")]
+    public IActionResult GET_api_preferences_storecctokens_63e1d99d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/task")]
+    public IActionResult GET_api_preferences_task_6d75f6fe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/preferences/task-options")]
+    public IActionResult GET_api_preferences_task_options_e02372f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/AccountingCashIncomeAccount")]
+    public IActionResult GET_api_prefs_AccountingCashIncomeAccount_af3331dd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/AccountingDepositAccounts")]
+    public IActionResult GET_api_prefs_AccountingDepositAccounts_f2ce9932() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/AccountingIncomeAccount")]
+    public IActionResult GET_api_prefs_AccountingIncomeAccount_1f2137a4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClaimReportComputerName")]
+    public IActionResult GET_api_prefs_ClaimReportComputerName_c6e99e77() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClaimReportReceiveInterval")]
+    public IActionResult GET_api_prefs_ClaimReportReceiveInterval_72799627() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClaimReportReceiveTime")]
+    public IActionResult GET_api_prefs_ClaimReportReceiveTime_a82bb9ca() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClaimReportReceivedByService")]
+    public IActionResult GET_api_prefs_ClaimReportReceivedByService_a0331f67() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClearinghouseDefaultDent")]
+    public IActionResult GET_api_prefs_ClearinghouseDefaultDent_5c7308b9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClearinghouseDefaultEligibility")]
+    public IActionResult GET_api_prefs_ClearinghouseDefaultEligibility_64cfdf89() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ClearinghouseDefaultMed")]
+    public IActionResult GET_api_prefs_ClearinghouseDefaultMed_814f7902() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/DatabaseMaintenanceSkipCheckTable")]
+    public IActionResult GET_api_prefs_DatabaseMaintenanceSkipCheckTable_abc341c6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/ItransImportFields")]
+    public IActionResult GET_api_prefs_ItransImportFields_d00731b5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/StoreCCtokens")]
+    public IActionResult GET_api_prefs_StoreCCtokens_174f3297() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/TreatPlanDiscountPercent")]
+    public IActionResult GET_api_prefs_TreatPlanDiscountPercent_f98d1ffb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/UnschedDaysFuture")]
+    public IActionResult GET_api_prefs_UnschedDaysFuture_2bb52417() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/UnschedDaysPast")]
+    public IActionResult GET_api_prefs_UnschedDaysPast_47c50563() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/UpdateInProgressOnComputerName")]
+    public IActionResult GET_api_prefs_UpdateInProgressOnComputerName_50c14da8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prefs/{prefName}")]
+    public IActionResult GET_api_prefs__prefName__aca6b423() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prepayments")]
+    public IActionResult GET_api_prepayments_36e4eb3d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/prepayments/{id}")]
+    public IActionResult GET_api_prepayments__id__b8e8c3bf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/printers")]
+    public IActionResult GET_api_printers_1c0573d6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/printers/{id}")]
+    public IActionResult GET_api_printers__id__b9a7e8f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/proc-appt-colors")]
+    public IActionResult GET_api_proc_appt_colors_bcb3c928() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/proc-appt-colors/{id}")]
+    public IActionResult GET_api_proc_appt_colors__id__0529f8db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/proc-buttons")]
+    public IActionResult GET_api_proc_buttons_f8219df6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/proc-buttons/{id}")]
+    public IActionResult GET_api_proc_buttons__id__a6bc46d2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedure-codes")]
+    public IActionResult GET_api_procedure_codes_7ebbc270() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedure-codes/banding")]
+    public IActionResult GET_api_procedure_codes_banding_2c33805b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedure-codes/{code}")]
+    public IActionResult GET_api_procedure_codes__code__84dbc743() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedure-codes/{id}")]
+    public IActionResult GET_api_procedure_codes__id__1012f78b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedure-codes/{id}/details")]
+    public IActionResult GET_api_procedure_codes__id__details_75643bd7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedures")]
+    public IActionResult GET_api_procedures_61d8eabd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedures")]
+    public IActionResult GET_api_procedures_b9082247() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedures/broken-reasons")]
+    public IActionResult GET_api_procedures_broken_reasons_278aa5e2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/procedures/{id}")]
+    public IActionResult GET_api_procedures__id__456f18fd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-links")]
+    public IActionResult GET_api_program_links_4e10efca() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-links/output-file")]
+    public IActionResult GET_api_program_links_output_file_7cae16ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-links/{id}")]
+    public IActionResult GET_api_program_links__id__823af43c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-properties")]
+    public IActionResult GET_api_program_properties_024629c8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-properties")]
+    public IActionResult GET_api_program_properties_0eb73639() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-properties")]
+    public IActionResult GET_api_program_properties_34cc3e8d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-properties")]
+    public IActionResult GET_api_program_properties_98427e7a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/program-properties")]
+    public IActionResult GET_api_program_properties_f79f29c0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/AvaTax")]
+    public IActionResult GET_api_programs_AvaTax_abfdf1c4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/EdgeExpress")]
+    public IActionResult GET_api_programs_EdgeExpress_a24a1926() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/carecredit")]
+    public IActionResult GET_api_programs_carecredit_28744df1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/carecredit/properties")]
+    public IActionResult GET_api_programs_carecredit_properties_afce3db8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/eclinicalworks")]
+    public IActionResult GET_api_programs_eclinicalworks_cde93873() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/payconnect")]
+    public IActionResult GET_api_programs_payconnect_29f1702d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/payconnect/properties")]
+    public IActionResult GET_api_programs_payconnect_properties_f9fcc892() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/paysimple")]
+    public IActionResult GET_api_programs_paysimple_0ab5db2c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/paysimple/properties")]
+    public IActionResult GET_api_programs_paysimple_properties_8d707975() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/podium")]
+    public IActionResult GET_api_programs_podium_daccdf1e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/podium/properties")]
+    public IActionResult GET_api_programs_podium_properties_c8f3bcd4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/transworld")]
+    public IActionResult GET_api_programs_transworld_f1cc4c17() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/trojan-collect")]
+    public IActionResult GET_api_programs_trojan_collect_71e86f85() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/xcharge")]
+    public IActionResult GET_api_programs_xcharge_a68a0ad3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/xcharge/properties")]
+    public IActionResult GET_api_programs_xcharge_properties_d40569a4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/xdr")]
+    public IActionResult GET_api_programs_xdr_0c6ae86c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/programs/{name}")]
+    public IActionResult GET_api_programs__name__b756ceb5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/provider-identifiers")]
+    public IActionResult GET_api_provider_identifiers_91348b65() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/providerclinics")]
+    public IActionResult GET_api_providerclinics_fa90dea7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/providers")]
+    public IActionResult GET_api_providers_d8964aa5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/providers/{id}")]
+    public IActionResult GET_api_providers__id__78c0c6bc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/queries/running")]
+    public IActionResult GET_api_queries_running_f9fb6e2e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/query-favorites")]
+    public IActionResult GET_api_query_favorites_ec239592() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/question-defs")]
+    public IActionResult GET_api_question_defs_73a8a61d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/quickbooks/accounts")]
+    public IActionResult GET_api_quickbooks_accounts_8663671c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/quickbooks/online/authorize")]
+    public IActionResult GET_api_quickbooks_online_authorize_7c9fc566() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/radiology/mount-defs")]
+    public IActionResult GET_api_radiology_mount_defs_11cd9ce6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/radiology/mount-defs/{id}")]
+    public IActionResult GET_api_radiology_mount_defs__id__c6f97531() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/radiology/mount-items/{id}")]
+    public IActionResult GET_api_radiology_mount_items__id__948fffae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/radiology/orders")]
+    public IActionResult GET_api_radiology_orders_e32a3dea() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reactivation-rules")]
+    public IActionResult GET_api_reactivation_rules_a5064f4b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/recall-types")]
+    public IActionResult GET_api_recall_types_83a03f12() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/recalls/asap")]
+    public IActionResult GET_api_recalls_asap_728b7f9b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/recalls/list")]
+    public IActionResult GET_api_recalls_list_0825e125() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/recalls/{patientId}")]
+    public IActionResult GET_api_recalls__patientId__2842e675() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reconciles")]
+    public IActionResult GET_api_reconciles_a68acecf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/recurring-charges/history")]
+    public IActionResult GET_api_recurring_charges_history_05f3a4af() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/references")]
+    public IActionResult GET_api_references_65b8bed8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/referral-attachments")]
+    public IActionResult GET_api_referral_attachments_42b6f3cc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/referral-procedures")]
+    public IActionResult GET_api_referral_procedures_3daea9b1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/registration-keys")]
+    public IActionResult GET_api_registration_keys_341649cf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/registration-keys/patients")]
+    public IActionResult GET_api_registration_keys_patients_90f873a9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reminder-rules")]
+    public IActionResult GET_api_reminder_rules_51a141cf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reminder-rules")]
+    public IActionResult GET_api_reminder_rules_9cc720bd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/replication/servers")]
+    public IActionResult GET_api_replication_servers_1e59ec8c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reports")]
+    public IActionResult GET_api_reports_64c98a16() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reports/filter")]
+    public IActionResult GET_api_reports_filter_74b70fe6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/reports/setup")]
+    public IActionResult GET_api_reports_setup_5314e5eb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/required-fields")]
+    public IActionResult GET_api_required_fields_01e81926() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/required-fields")]
+    public IActionResult GET_api_required_fields_ff2715e7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/requirements/{id}/students")]
+    public IActionResult GET_api_requirements__id__students_b39aaebf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/requirements/{id}/students/{studentId}")]
+    public IActionResult GET_api_requirements__id__students__studentId__77d6547a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/resellers")]
+    public IActionResult GET_api_resellers_e35e8dc1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/resellers/{id}")]
+    public IActionResult GET_api_resellers__id__26357d6b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/rxnorms/search")]
+    public IActionResult GET_api_rxnorms_search_9d61e46b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/rxnorms/{rxCui}")]
+    public IActionResult GET_api_rxnorms__rxCui__9377bc40() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/scanner-settings")]
+    public IActionResult GET_api_scanner_settings_9763c8d7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/schedule-openings")]
+    public IActionResult GET_api_schedule_openings_0ec30d6f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/scheduled-processes")]
+    public IActionResult GET_api_scheduled_processes_8b07479d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/schedules")]
+    public IActionResult GET_api_schedules_6113627c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/school-classes")]
+    public IActionResult GET_api_school_classes_d17aa2a2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/screen-groups")]
+    public IActionResult GET_api_screen_groups_d97792d7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/secure-email/settings")]
+    public IActionResult GET_api_secure_email_settings_f228e9df() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/security-logs")]
+    public IActionResult GET_api_security_logs_cf3c32a1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/security/global")]
+    public IActionResult GET_api_security_global_f5550242() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/server-time")]
+    public IActionResult GET_api_server_time_32f0731c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/server/time")]
+    public IActionResult GET_api_server_time_1be64306() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/setup-wizard")]
+    public IActionResult GET_api_setup_wizard_743d8f5a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/setup-wizard/progress/{id}")]
+    public IActionResult GET_api_setup_wizard_progress__id__e1fbd264() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheet-defs")]
+    public IActionResult GET_api_sheet_defs_8f67a402() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheet-defs/defaults")]
+    public IActionResult GET_api_sheet_defs_defaults_2e87efbe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheet-defs/{id}")]
+    public IActionResult GET_api_sheet_defs__id__18e86406() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheet-field-defs")]
+    public IActionResult GET_api_sheet_field_defs_851a8807() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheet-field-defs")]
+    public IActionResult GET_api_sheet_field_defs_dbf478b5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheets")]
+    public IActionResult GET_api_sheets_02a49181() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sheets/import-enums")]
+    public IActionResult GET_api_sheets_import_enums_21c5fc12() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sites")]
+    public IActionResult GET_api_sites_83d61233() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sms/credits")]
+    public IActionResult GET_api_sms_credits_4e97c95c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/sms/messages")]
+    public IActionResult GET_api_sms_messages_fbb0a20a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/snomed")]
+    public IActionResult GET_api_snomed_a461b51d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/snomeds")]
+    public IActionResult GET_api_snomeds_535a33dd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/snomeds/{code}")]
+    public IActionResult GET_api_snomeds__code__9407434b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/state-abbreviations")]
+    public IActionResult GET_api_state_abbreviations_cf3ff94d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/statements")]
+    public IActionResult GET_api_statements_e457e9e5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/subscribers")]
+    public IActionResult GET_api_subscribers_700632fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/summary-ccds")]
+    public IActionResult GET_api_summary_ccds_629bb394() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/summary-ccds/{id}")]
+    public IActionResult GET_api_summary_ccds__id__4d91b7aa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/suppliers")]
+    public IActionResult GET_api_suppliers_562690f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/supplies")]
+    public IActionResult GET_api_supplies_cd20dc1f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/supplies/inventory")]
+    public IActionResult GET_api_supplies_inventory_5c9d7870() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/supply-orders")]
+    public IActionResult GET_api_supply_orders_3f5c7c28() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/support/status")]
+    public IActionResult GET_api_support_status_12b1a2b0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/task-lists")]
+    public IActionResult GET_api_task_lists_cef2e176() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/tasks")]
+    public IActionResult GET_api_tasks_13f65e8d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/tasks/search")]
+    public IActionResult GET_api_tasks_search_f2b769d9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/tasks/{id}/history")]
+    public IActionResult GET_api_tasks__id__history_a4b53912() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/tasks/{taskId}/attachments")]
+    public IActionResult GET_api_tasks__taskId__attachments_a01da475() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/tasks/{taskId}/subscribers")]
+    public IActionResult GET_api_tasks__taskId__subscribers_59a06643() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/terminalactives")]
+    public IActionResult GET_api_terminalactives_d7363955() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/terminalactives")]
+    public IActionResult GET_api_terminalactives_df56633d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/testmode/overrides/{entity}")]
+    public IActionResult GET_api_testmode_overrides__entity__c4a9af0e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/time/server")]
+    public IActionResult GET_api_time_server_b61a7066() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/timeadjusts")]
+    public IActionResult GET_api_timeadjusts_0e09796a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/timeadjusts")]
+    public IActionResult GET_api_timeadjusts_90a503b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/timeadjusts/{id}")]
+    public IActionResult GET_api_timeadjusts__id__59402398() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/timecardrules")]
+    public IActionResult GET_api_timecardrules_6cd06946() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/transactioninvoices/{id}")]
+    public IActionResult GET_api_transactioninvoices__id__21e0f50e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/translations")]
+    public IActionResult GET_api_translations_162e1f8e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/translations/categories")]
+    public IActionResult GET_api_translations_categories_3e131e03() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/translations/export")]
+    public IActionResult GET_api_translations_export_f9aeaf9c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/treatment-plans/{id}")]
+    public IActionResult GET_api_treatment_plans__id__f7513972() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/trojan/help")]
+    public IActionResult GET_api_trojan_help_dbc31bf6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/tsi-translogs")]
+    public IActionResult GET_api_tsi_translogs_727cbdcf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ucum-codes")]
+    public IActionResult GET_api_ucum_codes_e88733fd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ucums")]
+    public IActionResult GET_api_ucums_12671caa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/ucums")]
+    public IActionResult GET_api_ucums_ece4bb0b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/update-histories/version/{version}")]
+    public IActionResult GET_api_update_histories_version__version__418b95de() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/updates")]
+    public IActionResult GET_api_updates_9bd3eaa0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/updates/history")]
+    public IActionResult GET_api_updates_history_c6e6959d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/updates/in-progress")]
+    public IActionResult GET_api_updates_in_progress_ae558e68() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/updates/setup")]
+    public IActionResult GET_api_updates_setup_ec5411cd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/user-groups")]
+    public IActionResult GET_api_user_groups_badb60f4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/user-prefs/{userId}/AutoNoteExpandedCats")]
+    public IActionResult GET_api_user_prefs__userId__AutoNoteExpandedCats_86022eae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/user-prefs/{userId}/wiki-homepage")]
+    public IActionResult GET_api_user_prefs__userId__wiki_homepage_764b0a90() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/usergroups")]
+    public IActionResult GET_api_usergroups_42e0c4f8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/users")]
+    public IActionResult GET_api_users_1e2e8982() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/users")]
+    public IActionResult GET_api_users_9e529516() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/users/{id}/cds-permissions")]
+    public IActionResult GET_api_users__id__cds_permissions_efc28fe8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/vaccine-defs")]
+    public IActionResult GET_api_vaccine_defs_f73586f0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/videos/{id}")]
+    public IActionResult GET_api_videos__id__b34eaab4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/vitalsigns/patients/{id}")]
+    public IActionResult GET_api_vitalsigns_patients__id__ac7ee02a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/web-browser")]
+    public IActionResult GET_api_web_browser_50958685() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/web-forms/forms")]
+    public IActionResult GET_api_web_forms_forms_df667cbc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/web-forms/preferences")]
+    public IActionResult GET_api_web_forms_preferences_ecd87774() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/web-forms/sheet-defs")]
+    public IActionResult GET_api_web_forms_sheet_defs_eab2e4c1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webchat/messages")]
+    public IActionResult GET_api_webchat_messages_13321c66() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webchat/sessions")]
+    public IActionResult GET_api_webchat_sessions_e8c71e94() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webchat/sessions/{id}")]
+    public IActionResult GET_api_webchat_sessions__id__c6429d90() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webchat/sessions/{id}/messages")]
+    public IActionResult GET_api_webchat_sessions__id__messages_7dbbdaf7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webchat/sessions/{id}/notes")]
+    public IActionResult GET_api_webchat_sessions__id__notes_6119a855() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webchat/surveys")]
+    public IActionResult GET_api_webchat_surveys_0d707f54() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webforms/next")]
+    public IActionResult GET_api_webforms_next_f03b3e02() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/webview")]
+    public IActionResult GET_api_webview_f9214767() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/files")]
+    public IActionResult GET_api_wiki_files_04626dde() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/lists")]
+    public IActionResult GET_api_wiki_lists_e38bf299() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/lists/{id}")]
+    public IActionResult GET_api_wiki_lists__id__b34c0152() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/lists/{id}/headers")]
+    public IActionResult GET_api_wiki_lists__id__headers_c5101c0e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/lists/{id}/history")]
+    public IActionResult GET_api_wiki_lists__id__history_c89734bd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/lists/{listId}/items/{itemId}")]
+    public IActionResult GET_api_wiki_lists__listId__items__itemId__c43af8ec() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/pages")]
+    public IActionResult GET_api_wiki_pages_56ffd32d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/pages/{title}")]
+    public IActionResult GET_api_wiki_pages__title__5ead69ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/pages/{title}/drafts")]
+    public IActionResult GET_api_wiki_pages__title__drafts_ff39bac4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/pages/{title}/history")]
+    public IActionResult GET_api_wiki_pages__title__history_b8b206db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/pages/{title}/incoming-links")]
+    public IActionResult GET_api_wiki_pages__title__incoming_links_de2a91cc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/pages/{title}/revisions")]
+    public IActionResult GET_api_wiki_pages__title__revisions_c3601266() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/wiki/search")]
+    public IActionResult GET_api_wiki_search_d3715606() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpGet("/api/xweb/transactions")]
+    public IActionResult GET_api_xweb_transactions_b7fa5e89() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/alerts/{id}/read")]
+    public IActionResult PATCH_api_alerts__id__read_e87e1544() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/anesthesia/medications/{medId}/doses/{doseId}")]
+    public IActionResult PATCH_api_anesthesia_medications__medId__doses__doseId__a9141eee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/appointments/{id}")]
+    public IActionResult PATCH_api_appointments__id__18b55390() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/appointments/{id}/confirmation")]
+    public IActionResult PATCH_api_appointments__id__confirmation_977d8d34() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/appointments/{id}/priority")]
+    public IActionResult PATCH_api_appointments__id__priority_41e97503() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/ar-manager/patients/{id}/status")]
+    public IActionResult PATCH_api_ar_manager_patients__id__status_873d163c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/bug-submission-hashes")]
+    public IActionResult PATCH_api_bug_submission_hashes_c0f075db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/claim-attachments/{id}")]
+    public IActionResult PATCH_api_claim_attachments__id__396f03a2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/claim-form-items/{id}")]
+    public IActionResult PATCH_api_claim_form_items__id__a80dbd44() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/cloud/accounts/{id}/session-limit")]
+    public IActionResult PATCH_api_cloud_accounts__id__session_limit_c45dde3e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/dosespot/users/{id}")]
+    public IActionResult PATCH_api_dosespot_users__id__698c9d85() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/financial/amounts/{id}")]
+    public IActionResult PATCH_api_financial_amounts__id__94a0fdda() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/proc-buttons/{id}")]
+    public IActionResult PATCH_api_proc_buttons__id__e4d1888f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/procedures/{id}")]
+    public IActionResult PATCH_api_procedures__id__21095988() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/procedures/{id}/notes")]
+    public IActionResult PATCH_api_procedures__id__notes_eb09dafa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/procedures/{id}/status")]
+    public IActionResult PATCH_api_procedures__id__status_5d0eb360() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/providers/students/bulk")]
+    public IActionResult PATCH_api_providers_students_bulk_6ada4f00() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/repeat-charges/bulk")]
+    public IActionResult PATCH_api_repeat_charges_bulk_77eae88f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/supplies/inventory")]
+    public IActionResult PATCH_api_supplies_inventory_32e5de36() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/terminalactives/{id}")]
+    public IActionResult PATCH_api_terminalactives__id__83daa0a6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/text-messages/{id}")]
+    public IActionResult PATCH_api_text_messages__id__9968c898() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/translations/{id}")]
+    public IActionResult PATCH_api_translations__id__02641a39() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/treatment-plans/{id}")]
+    public IActionResult PATCH_api_treatment_plans__id__857f0b60() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/users/{id}/password")]
+    public IActionResult PATCH_api_users__id__password_5567b538() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPatch("/api/users/{id}/preferences")]
+    public IActionResult PATCH_api_users__id__preferences_c35fede0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/accounting-auto-pays")]
+    public IActionResult POST_api_accounting_auto_pays_7e46969b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/accounts")]
+    public IActionResult POST_api_accounts_6747c7a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/addresses")]
+    public IActionResult POST_api_addresses_2c6bc03d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/adjustments")]
+    public IActionResult POST_api_adjustments_e6e9b7f3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/advertising-postcards/accounts")]
+    public IActionResult POST_api_advertising_postcards_accounts_5ea4f892() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/advertising-postcards/patient-lists")]
+    public IActionResult POST_api_advertising_postcards_patient_lists_68ead55d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/alert-categories")]
+    public IActionResult POST_api_alert_categories_a811d081() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/alert-categories/{id}/links")]
+    public IActionResult POST_api_alert_categories__id__links_4c8cd7ab() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/allergies/reconcile")]
+    public IActionResult POST_api_allergies_reconcile_c6d044db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/allergy-defs")]
+    public IActionResult POST_api_allergy_defs_71ccf8c2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/allergy-defs/merge")]
+    public IActionResult POST_api_allergy_defs_merge_a2f0fd13() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthesia/med-suppliers")]
+    public IActionResult POST_api_anesthesia_med_suppliers_7eff61c8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthesia/medications")]
+    public IActionResult POST_api_anesthesia_medications_97fd11f8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthesia/medications/{id}/adjustments")]
+    public IActionResult POST_api_anesthesia_medications__id__adjustments_2cbf7a10() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthesia/medications/{id}/intake")]
+    public IActionResult POST_api_anesthesia_medications__id__intake_0238835f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthesia/medications/{id}/waste")]
+    public IActionResult POST_api_anesthesia_medications__id__waste_cbc1d68b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthetic-records")]
+    public IActionResult POST_api_anesthetic_records_15678578() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthetic-records/{id}/medications")]
+    public IActionResult POST_api_anesthetic_records__id__medications_9b0bf3e8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthetic-records/{id}/vitals")]
+    public IActionResult POST_api_anesthetic_records__id__vitals_df9df883() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/anesthetic-records/{recordId}/score")]
+    public IActionResult POST_api_anesthetic_records__recordId__score_64ee6a83() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/appointments")]
+    public IActionResult POST_api_appointments_9a6d4d01() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/appointments/{id}/tasks")]
+    public IActionResult POST_api_appointments__id__tasks_90c0d127() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/appt-field-defs")]
+    public IActionResult POST_api_appt_field_defs_fdb8cb7e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/appt-reminder-rules")]
+    public IActionResult POST_api_appt_reminder_rules_278631f3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/appt-rules")]
+    public IActionResult POST_api_appt_rules_b7840ab0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/appt-types")]
+    public IActionResult POST_api_appt_types_8fe1d5ff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ar-manager/patients/{id}/placements")]
+    public IActionResult POST_api_ar_manager_patients__id__placements_6ae51ad3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/asap-communications")]
+    public IActionResult POST_api_asap_communications_3c7dc293() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/audio-recordings")]
+    public IActionResult POST_api_audio_recordings_a24d708a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auth/login")]
+    public IActionResult POST_api_auth_login_3a09fdeb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-code-conds")]
+    public IActionResult POST_api_auto_code_conds_8e3536aa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-code-items")]
+    public IActionResult POST_api_auto_code_items_fa4716a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-codes")]
+    public IActionResult POST_api_auto_codes_c6d7a7f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-comm-exclude-dates")]
+    public IActionResult POST_api_auto_comm_exclude_dates_b4990e56() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-note-controls")]
+    public IActionResult POST_api_auto_note_controls_ae1cc50a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-notes")]
+    public IActionResult POST_api_auto_notes_3155bf7c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-notes/export")]
+    public IActionResult POST_api_auto_notes_export_a0f5367e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/auto-notes/import")]
+    public IActionResult POST_api_auto_notes_import_db95795e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/automation-conditions")]
+    public IActionResult POST_api_automation_conditions_3cf605ec() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/automations")]
+    public IActionResult POST_api_automations_35001cd0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/benefits")]
+    public IActionResult POST_api_benefits_286eb829() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/blockouts/copy")]
+    public IActionResult POST_api_blockouts_copy_6fb3fd84() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/bugs")]
+    public IActionResult POST_api_bugs_137453a1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/canadian/outstanding-transactions")]
+    public IActionResult POST_api_canadian_outstanding_transactions_a77e1b57() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/canadian/payment-reconciliations")]
+    public IActionResult POST_api_canadian_payment_reconciliations_59d762be() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/canadian/summary-reconciliations")]
+    public IActionResult POST_api_canadian_summary_reconciliations_cd425ff1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/admin")]
+    public IActionResult POST_api_carecredit_admin_161ebeb3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/applications")]
+    public IActionResult POST_api_carecredit_applications_d72b69ad() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/lookups")]
+    public IActionResult POST_api_carecredit_lookups_22ae5b27() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/reports")]
+    public IActionResult POST_api_carecredit_reports_caeeff02() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/transactions/{id}/acknowledge")]
+    public IActionResult POST_api_carecredit_transactions__id__acknowledge_a37dd16c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/transactions/{id}/refund")]
+    public IActionResult POST_api_carecredit_transactions__id__refund_87da5048() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carecredit/transactions/{id}/reprocess")]
+    public IActionResult POST_api_carecredit_transactions__id__reprocess_ba668da6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carriers")]
+    public IActionResult POST_api_carriers_dde62906() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/carriers/combine")]
+    public IActionResult POST_api_carriers_combine_1eb52a27() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/cds-triggers")]
+    public IActionResult POST_api_cds_triggers_1c1eda1c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/central-connections/validate")]
+    public IActionResult POST_api_central_connections_validate_e5eadd89() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/cert-employees")]
+    public IActionResult POST_api_cert_employees_c2a42d91() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/certs")]
+    public IActionResult POST_api_certs_8c05c9c5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/chart-views")]
+    public IActionResult POST_api_chart_views_6aa7ecb7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claim-attachments")]
+    public IActionResult POST_api_claim_attachments_484e035c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claim-forms")]
+    public IActionResult POST_api_claim_forms_94bff2db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claim-forms/{id}/items")]
+    public IActionResult POST_api_claim_forms__id__items_89d10316() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claim-payments")]
+    public IActionResult POST_api_claim_payments_e4071de1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claim-procs")]
+    public IActionResult POST_api_claim_procs_c479bb64() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claims/{id}/attachments")]
+    public IActionResult POST_api_claims__id__attachments_b63fc971() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claims/{id}/resend")]
+    public IActionResult POST_api_claims__id__resend_9492b619() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claims/{id}/send")]
+    public IActionResult POST_api_claims__id__send_13dd71cf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claims/{id}/trackings")]
+    public IActionResult POST_api_claims__id__trackings_ad4138cb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/claims/{id}/validate")]
+    public IActionResult POST_api_claims__id__validate_7ba0c4e4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/clearinghouses")]
+    public IActionResult POST_api_clearinghouses_52a190f6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/clearinghouses/{id}/retrieve-reports")]
+    public IActionResult POST_api_clearinghouses__id__retrieve_reports_4ba8532a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/clock-events")]
+    public IActionResult POST_api_clock_events_1f79f067() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/cloud-users")]
+    public IActionResult POST_api_cloud_users_d45037a0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/cloud/password")]
+    public IActionResult POST_api_cloud_password_0a2b4d41() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/code-groups")]
+    public IActionResult POST_api_code_groups_d94df66f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/code-systems/import")]
+    public IActionResult POST_api_code_systems_import_3b3cebce() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/commlogs")]
+    public IActionResult POST_api_commlogs_268a4c17() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/computers")]
+    public IActionResult POST_api_computers_13f19eb3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/contacts")]
+    public IActionResult POST_api_contacts_86c69fa4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/counties")]
+    public IActionResult POST_api_counties_3d4cdbb2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/cpts")]
+    public IActionResult POST_api_cpts_999aa108() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/credit-cards")]
+    public IActionResult POST_api_credit_cards_486bdba0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/credit-cards/default-procs-sync")]
+    public IActionResult POST_api_credit_cards_default_procs_sync_f4006d00() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/credit-recurring-charges/run")]
+    public IActionResult POST_api_credit_recurring_charges_run_99372533() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/database-maintenance/backup")]
+    public IActionResult POST_api_database_maintenance_backup_9fa1be1c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/database-maintenance/fix-claimproc-duplicates")]
+    public IActionResult POST_api_database_maintenance_fix_claimproc_duplicates_9a096c1c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/database-maintenance/fix-missing-claim-procs")]
+    public IActionResult POST_api_database_maintenance_fix_missing_claim_procs_3c1ad606() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/database-maintenance/patient-run")]
+    public IActionResult POST_api_database_maintenance_patient_run_ea42c219() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/database-maintenance/run")]
+    public IActionResult POST_api_database_maintenance_run_a109719f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/def-links")]
+    public IActionResult POST_api_def_links_1e5b866f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/definitions")]
+    public IActionResult POST_api_definitions_721457e9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/definitions/billing-types/{fromId}/merge/{intoId}")]
+    public IActionResult POST_api_definitions_billing_types__fromId__merge__intoId__9dbcc130() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/deposits")]
+    public IActionResult POST_api_deposits_1d9ee8f6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/discount-plan-subs")]
+    public IActionResult POST_api_discount_plan_subs_81fc08cc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/discount-plans")]
+    public IActionResult POST_api_discount_plans_94cd7bdc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/discount-plans/{from}/merge/{to}")]
+    public IActionResult POST_api_discount_plans__from__merge__to__a07fcbcd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/disease-defs")]
+    public IActionResult POST_api_disease_defs_1b083cde() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/display-field-categories")]
+    public IActionResult POST_api_display_field_categories_de6f448f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/dropbox/authorize")]
+    public IActionResult POST_api_dropbox_authorize_dd05c8d7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/dunning-messages")]
+    public IActionResult POST_api_dunning_messages_d2015087() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eclipboards/definitions")]
+    public IActionResult POST_api_eclipboards_definitions_5ac237a9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eclipboards/imagecapturedefs")]
+    public IActionResult POST_api_eclipboards_imagecapturedefs_52d23ad1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eclipboards/sheetrules")]
+    public IActionResult POST_api_eclipboards_sheetrules_ee0fe703() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ecw/diagnostics")]
+    public IActionResult POST_api_ecw_diagnostics_c5c1358d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ecw/diagnostics/query")]
+    public IActionResult POST_api_ecw_diagnostics_query_186e83a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/edgeexpress/transactions")]
+    public IActionResult POST_api_edgeexpress_transactions_ab6790c2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/edu-resources")]
+    public IActionResult POST_api_edu_resources_cba2a9b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr-measure-events")]
+    public IActionResult POST_api_ehr_measure_events_c57ee4c2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/amendments")]
+    public IActionResult POST_api_ehr_amendments_fcc3ddfe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/apt-observations")]
+    public IActionResult POST_api_ehr_apt_observations_cb53c029() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/care-plans")]
+    public IActionResult POST_api_ehr_care_plans_2b14e356() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/ccd/summary")]
+    public IActionResult POST_api_ehr_ccd_summary_0f3b603c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/lab-panels/import")]
+    public IActionResult POST_api_ehr_lab_panels_import_01432597() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/labs")]
+    public IActionResult POST_api_ehr_labs_a2e312be() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/labs/import")]
+    public IActionResult POST_api_ehr_labs_import_865448d1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/not-performed")]
+    public IActionResult POST_api_ehr_not_performed_dac83485() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/quarterly-keys")]
+    public IActionResult POST_api_ehr_quarterly_keys_1b249de1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/quarterly-keys/generate")]
+    public IActionResult POST_api_ehr_quarterly_keys_generate_15dbb7cf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/vaccine-defs")]
+    public IActionResult POST_api_ehr_vaccine_defs_ed5e1422() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ehr/vaccines")]
+    public IActionResult POST_api_ehr_vaccines_59a289ea() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/elect-ids")]
+    public IActionResult POST_api_elect_ids_d002826c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-addresses")]
+    public IActionResult POST_api_email_addresses_c9b909a9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-autographs")]
+    public IActionResult POST_api_email_autographs_b47f6a00() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-certificates/register")]
+    public IActionResult POST_api_email_certificates_register_2c0d357f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-certificates/sign")]
+    public IActionResult POST_api_email_certificates_sign_b6e368af() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-hosting/addresses/verify")]
+    public IActionResult POST_api_email_hosting_addresses_verify_4f7b98c1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-hosting/signatures")]
+    public IActionResult POST_api_email_hosting_signatures_55d69bac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-messages")]
+    public IActionResult POST_api_email_messages_8322e71f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email-templates")]
+    public IActionResult POST_api_email_templates_e9e1ba40() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email/test-encryption")]
+    public IActionResult POST_api_email_test_encryption_08be2022() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/email/test-hash")]
+    public IActionResult POST_api_email_test_hash_584c87e0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/employees")]
+    public IActionResult POST_api_employees_4fe86d09() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/employers")]
+    public IActionResult POST_api_employers_b95889ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/encounters")]
+    public IActionResult POST_api_encounters_d8447c77() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/equipment")]
+    public IActionResult POST_api_equipment_ce1a6238() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eroutingdefs")]
+    public IActionResult POST_api_eroutingdefs_fb75be06() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eroutings/{id}/acknowledge")]
+    public IActionResult POST_api_eroutings__id__acknowledge_25525197() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/erx/access")]
+    public IActionResult POST_api_erx_access_a5274ed1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/erx/session")]
+    public IActionResult POST_api_erx_session_bfaa61d9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eservices/2fa/send")]
+    public IActionResult POST_api_eservices_2fa_send_8b21b550() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eservices/2fa/verify")]
+    public IActionResult POST_api_eservices_2fa_verify_338b1f90() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eservices/econnector/restart")]
+    public IActionResult POST_api_eservices_econnector_restart_e1ef82dd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eservices/signup")]
+    public IActionResult POST_api_eservices_signup_ccdc95d0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/eservices/websched-asap/send")]
+    public IActionResult POST_api_eservices_websched_asap_send_5ae897ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/etrans/834/import")]
+    public IActionResult POST_api_etrans_834_import_1e6b733e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/etrans/834/preview")]
+    public IActionResult POST_api_etrans_834_preview_cec4c365() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/etrans/835/claims/{id}/pay")]
+    public IActionResult POST_api_etrans_835_claims__id__pay_16eb605f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/evaluation-criterion-defs")]
+    public IActionResult POST_api_evaluation_criterion_defs_a37a5306() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/evaluation-defs")]
+    public IActionResult POST_api_evaluation_defs_3a0ca34e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/evaluations")]
+    public IActionResult POST_api_evaluations_afb65c0f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/exam-sheets")]
+    public IActionResult POST_api_exam_sheets_93300bf8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/feature-requests")]
+    public IActionResult POST_api_feature_requests_14aeefb0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/fee-schedule-groups")]
+    public IActionResult POST_api_fee_schedule_groups_9aefe4cc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/fee-schedules")]
+    public IActionResult POST_api_fee_schedules_237bc1dc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/fee-schedules/tools")]
+    public IActionResult POST_api_fee_schedules_tools_924b5b53() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/fhir/api-keys")]
+    public IActionResult POST_api_fhir_api_keys_b4a344e9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/fhir/api-keys/assign")]
+    public IActionResult POST_api_fhir_api_keys_assign_ee9eb92e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/field-def-links")]
+    public IActionResult POST_api_field_def_links_2b0700e3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/finance-charges")]
+    public IActionResult POST_api_finance_charges_aa60c86f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/grading-scales")]
+    public IActionResult POST_api_grading_scales_01594a6e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/hl7/definitions")]
+    public IActionResult POST_api_hl7_definitions_4002a330() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/image-categories/merge")]
+    public IActionResult POST_api_image_categories_merge_b84dc384() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/images")]
+    public IActionResult POST_api_images_adde8885() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/images/draw-color")]
+    public IActionResult POST_api_images_draw_color_cc8d32b1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/images/float")]
+    public IActionResult POST_api_images_float_9cdd9a83() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/imaging-devices")]
+    public IActionResult POST_api_imaging_devices_969c2929() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/income-transfers")]
+    public IActionResult POST_api_income_transfers_8d53b99e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/adjustments")]
+    public IActionResult POST_api_insurance_adjustments_b8c277f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/categories")]
+    public IActionResult POST_api_insurance_categories_9bbca041() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/filing-codes")]
+    public IActionResult POST_api_insurance_filing_codes_2e69f55a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/payments/fix")]
+    public IActionResult POST_api_insurance_payments_fix_bb05b588() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/plans")]
+    public IActionResult POST_api_insurance_plans_2e4057d4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/plans/convert")]
+    public IActionResult POST_api_insurance_plans_convert_e9ece0ab() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/insurance/plans/merge")]
+    public IActionResult POST_api_insurance_plans_merge_c7f15f57() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/interventions")]
+    public IActionResult POST_api_interventions_4e079b0d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/itrans/carriers/update")]
+    public IActionResult POST_api_itrans_carriers_update_c0b6072e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/jobs")]
+    public IActionResult POST_api_jobs_ed1ac2f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/journalentries")]
+    public IActionResult POST_api_journalentries_2f9d8a3f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/laboratories")]
+    public IActionResult POST_api_laboratories_ea1e4353() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/languages/definitions")]
+    public IActionResult POST_api_languages_definitions_5fc455a9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/late-charges")]
+    public IActionResult POST_api_late_charges_a851f2ed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/license")]
+    public IActionResult POST_api_license_75a1c6a4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/mass-email/send")]
+    public IActionResult POST_api_mass_email_send_32b7fd2f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/mass-email/templates")]
+    public IActionResult POST_api_mass_email_templates_5f54140d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/measure-events")]
+    public IActionResult POST_api_measure_events_6a7a4fd9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/medical-orders")]
+    public IActionResult POST_api_medical_orders_2077bbe9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/medications/merge")]
+    public IActionResult POST_api_medications_merge_26caf630() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/medications/reconcile")]
+    public IActionResult POST_api_medications_reconcile_9061777f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/mobile/code")]
+    public IActionResult POST_api_mobile_code_3ec8255f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/multi-visit-groups")]
+    public IActionResult POST_api_multi_visit_groups_5d2b04ab() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/operatories")]
+    public IActionResult POST_api_operatories_faa98ab1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ortho/auto-claims")]
+    public IActionResult POST_api_ortho_auto_claims_4df1b828() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/ortho/hardware")]
+    public IActionResult POST_api_ortho_hardware_3f26ab9b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patient-clones")]
+    public IActionResult POST_api_patient_clones_3bd1a6ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patient-list-elements")]
+    public IActionResult POST_api_patient_list_elements_dcdb6ac9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patient-lists/query")]
+    public IActionResult POST_api_patient_lists_query_135dc392() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patient-popups")]
+    public IActionResult POST_api_patient_popups_adbbae50() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patients/reformat-phone-numbers")]
+    public IActionResult POST_api_patients_reformat_phone_numbers_f1a9f74d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patients/{id}/allergies")]
+    public IActionResult POST_api_patients__id__allergies_71111dc9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/patients/{id}/ccd")]
+    public IActionResult POST_api_patients__id__ccd_57e5e8a9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payconnect/transactions")]
+    public IActionResult POST_api_payconnect_transactions_326fbc57() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payconnect2/transactions")]
+    public IActionResult POST_api_payconnect2_transactions_5df5e2ed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payments")]
+    public IActionResult POST_api_payments_441679af() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payor-types")]
+    public IActionResult POST_api_payor_types_800613ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payperiods")]
+    public IActionResult POST_api_payperiods_e5024496() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payplan-charges")]
+    public IActionResult POST_api_payplan_charges_2c5c2662() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payplan-credits")]
+    public IActionResult POST_api_payplan_credits_438affcd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payplan-templates")]
+    public IActionResult POST_api_payplan_templates_29bebd99() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payplans/{id}/dynamic")]
+    public IActionResult POST_api_payplans__id__dynamic_b55e33b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/payplans/{id}/recalculate")]
+    public IActionResult POST_api_payplans__id__recalculate_7874613d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/paysimple/transactions")]
+    public IActionResult POST_api_paysimple_transactions_8140fa1a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/paysplits")]
+    public IActionResult POST_api_paysplits_636b3c4f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/pharmacies")]
+    public IActionResult POST_api_pharmacies_01eed153() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/prepayments/allocate")]
+    public IActionResult POST_api_prepayments_allocate_fbe1fb6b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/prescriptions/combine")]
+    public IActionResult POST_api_prescriptions_combine_17edd84d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/printers")]
+    public IActionResult POST_api_printers_d8888a11() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/problems/reconcile")]
+    public IActionResult POST_api_problems_reconcile_5e6dc4f3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/proc-appt-colors")]
+    public IActionResult POST_api_proc_appt_colors_dc87ee83() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/proc-buttons")]
+    public IActionResult POST_api_proc_buttons_48dbce94() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/procedure-codes")]
+    public IActionResult POST_api_procedure_codes_f72c4818() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/procedures")]
+    public IActionResult POST_api_procedures_f6b73476() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/procedures/group")]
+    public IActionResult POST_api_procedures_group_e8bdfea5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/procedures/lock")]
+    public IActionResult POST_api_procedures_lock_1b339f7e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/procedures/tools")]
+    public IActionResult POST_api_procedures_tools_3b8ff807() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/program-links")]
+    public IActionResult POST_api_program_links_7d48d3bf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/queries/parse")]
+    public IActionResult POST_api_queries_parse_d7b2b3a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/query-favorites")]
+    public IActionResult POST_api_query_favorites_e44125df() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/question-defs")]
+    public IActionResult POST_api_question_defs_11b7749c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/radiology/mount-defs/generate")]
+    public IActionResult POST_api_radiology_mount_defs_generate_5ab99e64() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/recall-types")]
+    public IActionResult POST_api_recall_types_e2f42dae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/recalls/undo")]
+    public IActionResult POST_api_recalls_undo_c7c6c602() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/referrals/merge")]
+    public IActionResult POST_api_referrals_merge_10b6f7e9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/reminder-rules")]
+    public IActionResult POST_api_reminder_rules_dd8865a0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/repeat-charges/run")]
+    public IActionResult POST_api_repeat_charges_run_21d77955() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/requests")]
+    public IActionResult POST_api_requests_8794db4f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/requirements/{id}/field-conditions")]
+    public IActionResult POST_api_requirements__id__field_conditions_0ad8baee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/scheduled-processes")]
+    public IActionResult POST_api_scheduled_processes_9b6ceebe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/schedules")]
+    public IActionResult POST_api_schedules_b8f38c59() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/school-classes")]
+    public IActionResult POST_api_school_classes_42ff0bb0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/screen-groups")]
+    public IActionResult POST_api_screen_groups_956f8b9e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/screenshots")]
+    public IActionResult POST_api_screenshots_64b463af() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/security-logs")]
+    public IActionResult POST_api_security_logs_61679abc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/security/lock")]
+    public IActionResult POST_api_security_lock_57377959() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/security/unlock")]
+    public IActionResult POST_api_security_unlock_423ce672() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/securitylogs")]
+    public IActionResult POST_api_securitylogs_fe9015c5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/setup-wizard")]
+    public IActionResult POST_api_setup_wizard_193a314a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-defs")]
+    public IActionResult POST_api_sheet_defs_4b5d53ad() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-field-defs")]
+    public IActionResult POST_api_sheet_field_defs_f1ad7db0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields")]
+    public IActionResult POST_api_sheet_fields_e8528427() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/chart")]
+    public IActionResult POST_api_sheet_fields_chart_1c2e2fd6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/checkbox")]
+    public IActionResult POST_api_sheet_fields_checkbox_45382f2d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/combobox")]
+    public IActionResult POST_api_sheet_fields_combobox_1f8a3832() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/exam")]
+    public IActionResult POST_api_sheet_fields_exam_64a06e7c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/grid")]
+    public IActionResult POST_api_sheet_fields_grid_5b438ace() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/image")]
+    public IActionResult POST_api_sheet_fields_image_346092a2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/input")]
+    public IActionResult POST_api_sheet_fields_input_08d3dea9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/line")]
+    public IActionResult POST_api_sheet_fields_line_deebc699() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/output")]
+    public IActionResult POST_api_sheet_fields_output_74779f91() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/patient-image")]
+    public IActionResult POST_api_sheet_fields_patient_image_25e3af82() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/rect")]
+    public IActionResult POST_api_sheet_fields_rect_7d24e9bf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/signature")]
+    public IActionResult POST_api_sheet_fields_signature_3ffb0914() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/special")]
+    public IActionResult POST_api_sheet_fields_special_1f1a59df() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheet-fields/static")]
+    public IActionResult POST_api_sheet_fields_static_ba9b31ed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheets/checkin")]
+    public IActionResult POST_api_sheets_checkin_bc86062b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheets/export")]
+    public IActionResult POST_api_sheets_export_0d0b9046() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheets/import")]
+    public IActionResult POST_api_sheets_import_205f4794() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sheets/tools/copy")]
+    public IActionResult POST_api_sheets_tools_copy_f5cd9e5f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sig-button-defs")]
+    public IActionResult POST_api_sig_button_defs_f2990863() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sig-element-defs")]
+    public IActionResult POST_api_sig_element_defs_a491102d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/signalods")]
+    public IActionResult POST_api_signalods_bc0198f3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/sms/messages")]
+    public IActionResult POST_api_sms_messages_061593ad() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/spell-check")]
+    public IActionResult POST_api_spell_check_fdc868ab() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/state-abbreviations")]
+    public IActionResult POST_api_state_abbreviations_cfa2725e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/statements/send")]
+    public IActionResult POST_api_statements_send_29fc96d0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/subscribers/{id}/move")]
+    public IActionResult POST_api_subscribers__id__move_a72bc995() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/summary-ccds")]
+    public IActionResult POST_api_summary_ccds_a903644c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/suppliers")]
+    public IActionResult POST_api_suppliers_e9350a3a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/supplies")]
+    public IActionResult POST_api_supplies_b4491923() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/supply-orders")]
+    public IActionResult POST_api_supply_orders_edca3657() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/supply-orders/{orderId}/items")]
+    public IActionResult POST_api_supply_orders__orderId__items_5ddfc5ea() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/system/shutdown")]
+    public IActionResult POST_api_system_shutdown_51471c95() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/task-lists")]
+    public IActionResult POST_api_task_lists_584fb646() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/task-lists/{id}/block")]
+    public IActionResult POST_api_task_lists__id__block_67aa96ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/tasks")]
+    public IActionResult POST_api_tasks_18366fc3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/tasks/{taskId}/attachments")]
+    public IActionResult POST_api_tasks__taskId__attachments_df069bde() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/tasks/{taskId}/notes")]
+    public IActionResult POST_api_tasks__taskId__notes_1e198ed4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/tasks/{taskId}/subscribers")]
+    public IActionResult POST_api_tasks__taskId__subscribers_eebed90a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/terminalactives")]
+    public IActionResult POST_api_terminalactives_8645aca7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/terminals/connect")]
+    public IActionResult POST_api_terminals_connect_f14f8c77() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/text-messages")]
+    public IActionResult POST_api_text_messages_7779f9ab() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/text-messages/bulk")]
+    public IActionResult POST_api_text_messages_bulk_e1098236() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/timeadjusts")]
+    public IActionResult POST_api_timeadjusts_8dd9480c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/timecardrules")]
+    public IActionResult POST_api_timecardrules_474e0a13() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/transactions")]
+    public IActionResult POST_api_transactions_b013b49c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/translations")]
+    public IActionResult POST_api_translations_156fb4a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/translations/import")]
+    public IActionResult POST_api_translations_import_28d6e740() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/treatment-plans")]
+    public IActionResult POST_api_treatment_plans_6a17debe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/trojan/collect")]
+    public IActionResult POST_api_trojan_collect_22132491() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/updates/install-message")]
+    public IActionResult POST_api_updates_install_message_9d321cae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/user-queries")]
+    public IActionResult POST_api_user_queries_40e974e4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/users/dental-schools/update-groups")]
+    public IActionResult POST_api_users_dental_schools_update_groups_e383a2a5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/users/{id}/validate")]
+    public IActionResult POST_api_users__id__validate_f7b16ee4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/vaccine-defs")]
+    public IActionResult POST_api_vaccine_defs_65b3d56d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/web-forms/forms/acknowledge")]
+    public IActionResult POST_api_web_forms_forms_acknowledge_fda841fb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/web-mail/messages")]
+    public IActionResult POST_api_web_mail_messages_0bf23679() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/webchat/sessions")]
+    public IActionResult POST_api_webchat_sessions_35c63eb8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/webchat/sessions/{id}/end")]
+    public IActionResult POST_api_webchat_sessions__id__end_b0593559() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/webchat/sessions/{id}/messages")]
+    public IActionResult POST_api_webchat_sessions__id__messages_87f59b9d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/webchat/sessions/{id}/notes")]
+    public IActionResult POST_api_webchat_sessions__id__notes_cf1ddee6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/wiki/files")]
+    public IActionResult POST_api_wiki_files_da2d4cbd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/wiki/lists")]
+    public IActionResult POST_api_wiki_lists_ff17c30d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/wiki/lists/{listId}/items")]
+    public IActionResult POST_api_wiki_lists__listId__items_77e3c765() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/wiki/pages")]
+    public IActionResult POST_api_wiki_pages_419254c9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/xcharge/tokens/verify")]
+    public IActionResult POST_api_xcharge_tokens_verify_0dd9dade() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/xcharge/transactions/import")]
+    public IActionResult POST_api_xcharge_transactions_import_6c6ec7db() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPost("/api/xweb/transactions")]
+    public IActionResult POST_api_xweb_transactions_54126039() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/accounting-auto-pays/{id}")]
+    public IActionResult PUT_api_accounting_auto_pays__id__51e757f4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/accounts/{id}")]
+    public IActionResult PUT_api_accounts__id__bc2648ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/addresses/{id}")]
+    public IActionResult PUT_api_addresses__id__2b02a094() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/adjustments/{id}")]
+    public IActionResult PUT_api_adjustments__id__c084ce67() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/allergy-defs/{id}")]
+    public IActionResult PUT_api_allergy_defs__id__8c802346() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/anesthesia/med-suppliers/{id}")]
+    public IActionResult PUT_api_anesthesia_med_suppliers__id__2212c9ac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/anesthesia/medications/{id}")]
+    public IActionResult PUT_api_anesthesia_medications__id__01dd0a53() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/anesthetic-records/{id}")]
+    public IActionResult PUT_api_anesthetic_records__id__dfae230b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/anesthetic-records/{recordId}/score")]
+    public IActionResult PUT_api_anesthetic_records__recordId__score_bba2caec() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/appointments/{id}")]
+    public IActionResult PUT_api_appointments__id__5105677b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/appt-field-defs/{id}")]
+    public IActionResult PUT_api_appt_field_defs__id__6b1dc63f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/appt-reminder-rules/{id}")]
+    public IActionResult PUT_api_appt_reminder_rules__id__11008984() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/appt-rules/{id}")]
+    public IActionResult PUT_api_appt_rules__id__cae2a637() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/appt-types/{id}")]
+    public IActionResult PUT_api_appt_types__id__2f28f07c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/auto-code-items/{id}")]
+    public IActionResult PUT_api_auto_code_items__id__8563731e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/auto-codes/{id}")]
+    public IActionResult PUT_api_auto_codes__id__5cad2ae9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/auto-note-controls/{id}")]
+    public IActionResult PUT_api_auto_note_controls__id__3410be73() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/auto-notes/{id}")]
+    public IActionResult PUT_api_auto_notes__id__efc2a03d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/automation-conditions/{id}")]
+    public IActionResult PUT_api_automation_conditions__id__ff7f3d3b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/automations/{id}")]
+    public IActionResult PUT_api_automations__id__a656f92e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/benefits/{id}")]
+    public IActionResult PUT_api_benefits__id__ff85c41e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/bug-submissions")]
+    public IActionResult PUT_api_bug_submissions_7ed45336() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/carriers/{id}")]
+    public IActionResult PUT_api_carriers__id__00114a34() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/cds-triggers/{id}")]
+    public IActionResult PUT_api_cds_triggers__id__dc836339() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/cds/permissions/{id}")]
+    public IActionResult PUT_api_cds_permissions__id__9c9532c4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/central-users/{id}")]
+    public IActionResult PUT_api_central_users__id__74cabab2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/cert-employees/{id}")]
+    public IActionResult PUT_api_cert_employees__id__d770636a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/certs/{id}")]
+    public IActionResult PUT_api_certs__id__53bb1b29() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/chart-views/{id}")]
+    public IActionResult PUT_api_chart_views__id__4f36a98d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/chart-views/{id}/display-fields")]
+    public IActionResult PUT_api_chart_views__id__display_fields_36f2ead2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/claim-forms/{id}")]
+    public IActionResult PUT_api_claim_forms__id__8bd79333() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/claim-forms/{id}/items")]
+    public IActionResult PUT_api_claim_forms__id__items_0743aa45() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/claim-payments/{id}")]
+    public IActionResult PUT_api_claim_payments__id__a94486de() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/claim-procs/{id}")]
+    public IActionResult PUT_api_claim_procs__id__a0f1c19f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/claims/{id}")]
+    public IActionResult PUT_api_claims__id__f688e063() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/claims/{id}/trackings/{trackingId}")]
+    public IActionResult PUT_api_claims__id__trackings__trackingId__204692d4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clearinghouses/{id}")]
+    public IActionResult PUT_api_clearinghouses__id__ba8da053() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clinic-prefs")]
+    public IActionResult PUT_api_clinic_prefs_37c8cef2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clinic-prefs/{clinicId}/EConfirmExcludeDays")]
+    public IActionResult PUT_api_clinic_prefs__clinicId__EConfirmExcludeDays_df086ad4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clinic-prefs/{clinicId}/EConfirmExcludeDaysUseHQ")]
+    public IActionResult PUT_api_clinic_prefs__clinicId__EConfirmExcludeDaysUseHQ_cb3e6a08() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clinic-prefs/{clinicId}/advertising-postcard-guid")]
+    public IActionResult PUT_api_clinic_prefs__clinicId__advertising_postcard_guid_da34d676() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clinic-prefs/{clinicId}/{prefName}")]
+    public IActionResult PUT_api_clinic_prefs__clinicId___prefName__b39920b2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/clock-events/{id}")]
+    public IActionResult PUT_api_clock_events__id__a80d0910() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/cloud-users/{id}")]
+    public IActionResult PUT_api_cloud_users__id__0201ac40() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/code-groups/{id}")]
+    public IActionResult PUT_api_code_groups__id__ca190738() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/computerprefs/{id}")]
+    public IActionResult PUT_api_computerprefs__id__2b674934() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/computers/{id}")]
+    public IActionResult PUT_api_computers__id__ce03c98d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/contacts/{id}")]
+    public IActionResult PUT_api_contacts__id__a4450c67() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/counties/{id}")]
+    public IActionResult PUT_api_counties__id__8f212621() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/cpts/{id}")]
+    public IActionResult PUT_api_cpts__id__8e90ea31() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/credit-cards/{id}")]
+    public IActionResult PUT_api_credit_cards__id__37608437() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/definitions/{id}")]
+    public IActionResult PUT_api_definitions__id__d4b13d3b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/deposits/{id}")]
+    public IActionResult PUT_api_deposits__id__37c658b5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/discount-plan-subs/{id}")]
+    public IActionResult PUT_api_discount_plan_subs__id__16d13856() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/discount-plans/{id}")]
+    public IActionResult PUT_api_discount_plans__id__1a2dc9ec() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/disease-defs/{id}")]
+    public IActionResult PUT_api_disease_defs__id__a79ddfd0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/display-fields/ortho/{id}")]
+    public IActionResult PUT_api_display_fields_ortho__id__e37836ed() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/display-fields/{id}")]
+    public IActionResult PUT_api_display_fields__id__68bdd587() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/dosespot/properties/{id}")]
+    public IActionResult PUT_api_dosespot_properties__id__ecbdfbfd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/dunning-messages/{id}")]
+    public IActionResult PUT_api_dunning_messages__id__268d7c1f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ebills")]
+    public IActionResult PUT_api_ebills_5bcfbfc3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eclipboards/definitions/{id}")]
+    public IActionResult PUT_api_eclipboards_definitions__id__06eb9b7a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eclipboards/imagecapturedefs/{id}")]
+    public IActionResult PUT_api_eclipboards_imagecapturedefs__id__e3a92b73() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eclipboards/sheetrules/{id}")]
+    public IActionResult PUT_api_eclipboards_sheetrules__id__bf6af142() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/edu-resources/{id}")]
+    public IActionResult PUT_api_edu_resources__id__21e0919f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/amendments/{id}")]
+    public IActionResult PUT_api_ehr_amendments__id__f568413c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/apt-observations/{id}")]
+    public IActionResult PUT_api_ehr_apt_observations__id__cfe16d78() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/care-plans/{id}")]
+    public IActionResult PUT_api_ehr_care_plans__id__b688de2e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/lab-notes/{id}")]
+    public IActionResult PUT_api_ehr_lab_notes__id__0a9dacc7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/lab-panels/{id}")]
+    public IActionResult PUT_api_ehr_lab_panels__id__bde01f3b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/lab-results/{id}")]
+    public IActionResult PUT_api_ehr_lab_results__id__ff1774d4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/lab-specimens/{id}")]
+    public IActionResult PUT_api_ehr_lab_specimens__id__430b35b0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/labs/{id}")]
+    public IActionResult PUT_api_ehr_labs__id__569afea1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/labs/{labId}/images")]
+    public IActionResult PUT_api_ehr_labs__labId__images_66a2160a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/not-performed/{id}")]
+    public IActionResult PUT_api_ehr_not_performed__id__a54d33ae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/provider-keys/{id}")]
+    public IActionResult PUT_api_ehr_provider_keys__id__485c4a92() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/quarterly-keys/{id}")]
+    public IActionResult PUT_api_ehr_quarterly_keys__id__7eba9e6c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/vaccine-defs/{id}")]
+    public IActionResult PUT_api_ehr_vaccine_defs__id__baad6c7e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ehr/vaccines/{id}")]
+    public IActionResult PUT_api_ehr_vaccines__id__6db14011() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/elect-ids/{id}")]
+    public IActionResult PUT_api_elect_ids__id__16a49da0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/email-addresses/{id}")]
+    public IActionResult PUT_api_email_addresses__id__8b57996f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/email-autographs/{id}")]
+    public IActionResult PUT_api_email_autographs__id__881ba437() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/email-messages/{id}")]
+    public IActionResult PUT_api_email_messages__id__07b6c75f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/email-templates/{id}")]
+    public IActionResult PUT_api_email_templates__id__ae711799() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/employees/{id}")]
+    public IActionResult PUT_api_employees__id__3d9b41d6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/employers/{id}")]
+    public IActionResult PUT_api_employers__id__e9bde589() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/encounters/{id}")]
+    public IActionResult PUT_api_encounters__id__6e938749() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/equipment/{id}")]
+    public IActionResult PUT_api_equipment__id__4cb37673() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eroutingdefs/{id}")]
+    public IActionResult PUT_api_eroutingdefs__id__1fd0eb8e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eroutings/{id}")]
+    public IActionResult PUT_api_eroutings__id__d7f956e3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/automessages/advanced")]
+    public IActionResult PUT_api_eservices_automessages_advanced_cf25cdee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/automessages/preferences")]
+    public IActionResult PUT_api_eservices_automessages_preferences_881fd7aa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/automessages/{id}")]
+    public IActionResult PUT_api_eservices_automessages__id__e7e9e84e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/eclipboard/settings")]
+    public IActionResult PUT_api_eservices_eclipboard_settings_e71d5335() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/mobile/settings")]
+    public IActionResult PUT_api_eservices_mobile_settings_5f4cbf25() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/mobileweb/settings")]
+    public IActionResult PUT_api_eservices_mobileweb_settings_9ba691a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/preferences")]
+    public IActionResult PUT_api_eservices_preferences_00be2664() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/eservices/websched/hostedurls/{clinicId}")]
+    public IActionResult PUT_api_eservices_websched_hostedurls__clinicId__3b120390() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/etrans/270/{id}")]
+    public IActionResult PUT_api_etrans_270__id__731bb5a9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/etrans/835/claims/{id}")]
+    public IActionResult PUT_api_etrans_835_claims__id__668c7251() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/etrans/835/procedures/{id}")]
+    public IActionResult PUT_api_etrans_835_procedures__id__8fca211d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/evaluation-criterion-defs/{id}")]
+    public IActionResult PUT_api_evaluation_criterion_defs__id__0dddf36b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/evaluation-defs/{id}")]
+    public IActionResult PUT_api_evaluation_defs__id__d72217e8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/evaluations/{id}")]
+    public IActionResult PUT_api_evaluations__id__c15f444d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/exam-sheets/{id}")]
+    public IActionResult PUT_api_exam_sheets__id__f3e149e7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/family-health/{patientId}")]
+    public IActionResult PUT_api_family_health__patientId__8096ec2d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/fee-schedule-groups/{id}")]
+    public IActionResult PUT_api_fee_schedule_groups__id__6f661547() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/fee-schedules/{id}")]
+    public IActionResult PUT_api_fee_schedules__id__ba4e6bf4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/fees/{id}")]
+    public IActionResult PUT_api_fees__id__32538ef5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/fhir/settings")]
+    public IActionResult PUT_api_fhir_settings_f360cd3c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/grading-scales/{id}")]
+    public IActionResult PUT_api_grading_scales__id__678be389() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/graphics/settings")]
+    public IActionResult PUT_api_graphics_settings_03a56690() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/group-permissions/{id}")]
+    public IActionResult PUT_api_group_permissions__id__dbce5160() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/guardians/{id}")]
+    public IActionResult PUT_api_guardians__id__aad90210() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/hie/settings")]
+    public IActionResult PUT_api_hie_settings_106b698f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/hl7/definition-fields/{id}")]
+    public IActionResult PUT_api_hl7_definition_fields__id__04fbda9f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/hl7/definition-messages/{id}")]
+    public IActionResult PUT_api_hl7_definition_messages__id__5bc91504() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/hl7/definition-segments/{id}")]
+    public IActionResult PUT_api_hl7_definition_segments__id__d58e494c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/hl7/definitions/{id}")]
+    public IActionResult PUT_api_hl7_definitions__id__20ace7a5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/hl7/messages/{id}")]
+    public IActionResult PUT_api_hl7_messages__id__e5502d01() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/imaging-devices/{id}")]
+    public IActionResult PUT_api_imaging_devices__id__d573e2c0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/imaging/settings")]
+    public IActionResult PUT_api_imaging_settings_f54eb3f2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/installment-plans/{id}")]
+    public IActionResult PUT_api_installment_plans__id__3ff487d5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/categories/{id}")]
+    public IActionResult PUT_api_insurance_categories__id__889ec554() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/filing-codes/{id}")]
+    public IActionResult PUT_api_insurance_filing_codes__id__5f582951() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/history-settings")]
+    public IActionResult PUT_api_insurance_history_settings_5112cbee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/plans/{id}")]
+    public IActionResult PUT_api_insurance_plans__id__83f09e70() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/plans/{id}/overrides")]
+    public IActionResult PUT_api_insurance_plans__id__overrides_847b8b38() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/spans/{id}")]
+    public IActionResult PUT_api_insurance_spans__id__d1565ffa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/insurance/verification/settings")]
+    public IActionResult PUT_api_insurance_verification_settings_b1c6f427() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/interventions/{id}")]
+    public IActionResult PUT_api_interventions__id__b6ce190e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/journal-entries/{id}")]
+    public IActionResult PUT_api_journal_entries__id__e8c01b3e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/journalentries/{id}")]
+    public IActionResult PUT_api_journalentries__id__301a4299() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/lab-cases/{id}")]
+    public IActionResult PUT_api_lab_cases__id__ca76ac58() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/lab-turnarounds/{id}")]
+    public IActionResult PUT_api_lab_turnarounds__id__46b7f1de() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/laboratories/{id}")]
+    public IActionResult PUT_api_laboratories__id__2eb97c73() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/letters/merges/{id}")]
+    public IActionResult PUT_api_letters_merges__id__9dd18a9c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/letters/templates/{id}")]
+    public IActionResult PUT_api_letters_templates__id__5440fb69() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/map-areas/{id}")]
+    public IActionResult PUT_api_map_areas__id__0b8af9ef() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/markup-tables/{id}")]
+    public IActionResult PUT_api_markup_tables__id__00d13d0d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/mass-email/settings")]
+    public IActionResult PUT_api_mass_email_settings_217160cf() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/mass-email/templates/{id}")]
+    public IActionResult PUT_api_mass_email_templates__id__63457094() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/measure-events/{id}")]
+    public IActionResult PUT_api_measure_events__id__4ee8614a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/med-labs/{id}")]
+    public IActionResult PUT_api_med_labs__id__ded336a3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/medical-orders/{id}")]
+    public IActionResult PUT_api_medical_orders__id__327a0c14() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/medications/{id}")]
+    public IActionResult PUT_api_medications__id__752eeca6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/messages/pay/{id}")]
+    public IActionResult PUT_api_messages_pay__id__18dfcfc6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/messages/replacements/{id}")]
+    public IActionResult PUT_api_messages_replacements__id__b1e87eea() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/messaging/buttons")]
+    public IActionResult PUT_api_messaging_buttons_38e84859() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/messaging/settings")]
+    public IActionResult PUT_api_messaging_settings_921569c4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/mobile/branding/{id}")]
+    public IActionResult PUT_api_mobile_branding__id__f441d1e0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/newcrop/billing")]
+    public IActionResult PUT_api_newcrop_billing_62c23d90() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/odtouch/security")]
+    public IActionResult PUT_api_odtouch_security_ecc15879() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/operatories/{id}")]
+    public IActionResult PUT_api_operatories__id__f87852e4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ortho/cases/{id}")]
+    public IActionResult PUT_api_ortho_cases__id__6642e207() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ortho/charts/settings")]
+    public IActionResult PUT_api_ortho_charts_settings_1373f690() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ortho/charts/{id}")]
+    public IActionResult PUT_api_ortho_charts__id__64c16912() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ortho/hardware/specs/{id}")]
+    public IActionResult PUT_api_ortho_hardware_specs__id__d818093f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ortho/hardware/{id}")]
+    public IActionResult PUT_api_ortho_hardware__id__7e2fe292() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/ortho/rx/{id}")]
+    public IActionResult PUT_api_ortho_rx__id__239c3b32() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patient-field-defs/{id}")]
+    public IActionResult PUT_api_patient_field_defs__id__d0ba82c8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patient-fields/{id}")]
+    public IActionResult PUT_api_patient_fields__id__e8726242() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patient-list-elements/{id}")]
+    public IActionResult PUT_api_patient_list_elements__id__dd30b0fa() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patient-lists/ehr/elements/{id}")]
+    public IActionResult PUT_api_patient_lists_ehr_elements__id__dccdcc66() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patient-lists/elements/{id}")]
+    public IActionResult PUT_api_patient_lists_elements__id__dbfe3b9a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patients/{id}/allergies/{allergyId}")]
+    public IActionResult PUT_api_patients__id__allergies__allergyId__cd652e63() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patients/{id}/communication-preferences")]
+    public IActionResult PUT_api_patients__id__communication_preferences_868fb3dd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patients/{id}/forms/{formId}")]
+    public IActionResult PUT_api_patients__id__forms__formId__44537503() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/patients/{id}/medical")]
+    public IActionResult PUT_api_patients__id__medical_6a66c06a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payments/{id}")]
+    public IActionResult PUT_api_payments__id__9e302421() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payor-types/{id}")]
+    public IActionResult PUT_api_payor_types__id__d7f3776e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payperiods/{id}")]
+    public IActionResult PUT_api_payperiods__id__6bf0fee1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payplan-charges/{id}")]
+    public IActionResult PUT_api_payplan_charges__id__472fe6b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payplan-templates/{id}")]
+    public IActionResult PUT_api_payplan_templates__id__b85a3d9c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payplans/{id}")]
+    public IActionResult PUT_api_payplans__id__2d16b36a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/paysplits/{id}")]
+    public IActionResult PUT_api_paysplits__id__4387cb1b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/payterminals/{id}")]
+    public IActionResult PUT_api_payterminals__id__3a335ec1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/perio-exams/{id}")]
+    public IActionResult PUT_api_perio_exams__id__d9956d30() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/permissions")]
+    public IActionResult PUT_api_permissions_1c332b29() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/permissions/groups/{id}")]
+    public IActionResult PUT_api_permissions_groups__id__a027f4ad() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/pharmacies/{id}")]
+    public IActionResult PUT_api_pharmacies__id__a50208d4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/phone-numbers/{id}")]
+    public IActionResult PUT_api_phone_numbers__id__8332e1c1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/practice")]
+    public IActionResult PUT_api_practice_e2537ca4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences")]
+    public IActionResult PUT_api_preferences_d9253c9e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/CloudPasswordNeedsReset")]
+    public IActionResult PUT_api_preferences_CloudPasswordNeedsReset_46a3ac70() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/DefaultCCProcs")]
+    public IActionResult PUT_api_preferences_DefaultCCProcs_53594568() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/PlannedApptDaysFuture")]
+    public IActionResult PUT_api_preferences_PlannedApptDaysFuture_c1d8d4a7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/PlannedApptDaysPast")]
+    public IActionResult PUT_api_preferences_PlannedApptDaysPast_b513cc6d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/SecurityGroupForInstructors")]
+    public IActionResult PUT_api_preferences_SecurityGroupForInstructors_a191756d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/SecurityGroupForStudents")]
+    public IActionResult PUT_api_preferences_SecurityGroupForStudents_74bd2a2e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/TaskAttachmentCategory")]
+    public IActionResult PUT_api_preferences_TaskAttachmentCategory_782fd276() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/advertising-postcard-guid")]
+    public IActionResult PUT_api_preferences_advertising_postcard_guid_02a82729() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/confirmation")]
+    public IActionResult PUT_api_preferences_confirmation_ac15d161() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/features")]
+    public IActionResult PUT_api_preferences_features_f713eefd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/language")]
+    public IActionResult PUT_api_preferences_language_e3e4a123() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/path")]
+    public IActionResult PUT_api_preferences_path_ecd9c850() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/payment-plan-options")]
+    public IActionResult PUT_api_preferences_payment_plan_options_6e6347f1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/perio")]
+    public IActionResult PUT_api_preferences_perio_05763bae() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/perio-graphical")]
+    public IActionResult PUT_api_preferences_perio_graphical_c240a9b6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/perio-voice")]
+    public IActionResult PUT_api_preferences_perio_voice_0dba6a24() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/task")]
+    public IActionResult PUT_api_preferences_task_dc364f74() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/task-options")]
+    public IActionResult PUT_api_preferences_task_options_2e7a1a7b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/preferences/{name}")]
+    public IActionResult PUT_api_preferences__name__7be375d3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/AccountingCashIncomeAccount")]
+    public IActionResult PUT_api_prefs_AccountingCashIncomeAccount_69ad282e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/AccountingDepositAccounts")]
+    public IActionResult PUT_api_prefs_AccountingDepositAccounts_3eb33f2c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/AccountingIncomeAccount")]
+    public IActionResult PUT_api_prefs_AccountingIncomeAccount_57bb41fb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClaimReportComputerName")]
+    public IActionResult PUT_api_prefs_ClaimReportComputerName_80b96563() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClaimReportReceiveInterval")]
+    public IActionResult PUT_api_prefs_ClaimReportReceiveInterval_1c1614fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClaimReportReceiveTime")]
+    public IActionResult PUT_api_prefs_ClaimReportReceiveTime_43a56ba7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClaimReportReceivedByService")]
+    public IActionResult PUT_api_prefs_ClaimReportReceivedByService_7f128dfb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClearinghouseDefaultDent")]
+    public IActionResult PUT_api_prefs_ClearinghouseDefaultDent_bcbd8f2c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClearinghouseDefaultEligibility")]
+    public IActionResult PUT_api_prefs_ClearinghouseDefaultEligibility_21fa9c22() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ClearinghouseDefaultMed")]
+    public IActionResult PUT_api_prefs_ClearinghouseDefaultMed_d843737e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/DatabaseMaintenanceSkipCheckTable")]
+    public IActionResult PUT_api_prefs_DatabaseMaintenanceSkipCheckTable_a5fb0140() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/ItransImportFields")]
+    public IActionResult PUT_api_prefs_ItransImportFields_3fed2ded() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/UnschedDaysFuture")]
+    public IActionResult PUT_api_prefs_UnschedDaysFuture_48e92270() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/UnschedDaysPast")]
+    public IActionResult PUT_api_prefs_UnschedDaysPast_b8789f0b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/UpdateInProgressOnComputerName")]
+    public IActionResult PUT_api_prefs_UpdateInProgressOnComputerName_fab14ce3() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prefs/{prefName}")]
+    public IActionResult PUT_api_prefs__prefName__6e545a35() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prepayments/{id}")]
+    public IActionResult PUT_api_prepayments__id__297f44c6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/prescriptions/{id}")]
+    public IActionResult PUT_api_prescriptions__id__5685ca94() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/printers/{id}")]
+    public IActionResult PUT_api_printers__id__b129a05a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/proc-appt-colors/{id}")]
+    public IActionResult PUT_api_proc_appt_colors__id__1f29e0b4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/proc-buttons/{id}")]
+    public IActionResult PUT_api_proc_buttons__id__bd4eebf0() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/procedure-codes/{id}")]
+    public IActionResult PUT_api_procedure_codes__id__309d2ff4() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/procedure-codes/{id}/details")]
+    public IActionResult PUT_api_procedure_codes__id__details_4d5ecd90() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/procedure-codes/{id}/note")]
+    public IActionResult PUT_api_procedure_codes__id__note_b3ae7ae1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/procedures/batch")]
+    public IActionResult PUT_api_procedures_batch_d4234cb5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/procedures/{id}")]
+    public IActionResult PUT_api_procedures__id__017e9c98() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/program-links/{id}")]
+    public IActionResult PUT_api_program_links__id__b9a645c6() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/program-properties")]
+    public IActionResult PUT_api_program_properties_9d81cb25() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/program-properties")]
+    public IActionResult PUT_api_program_properties_b767e999() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/program-properties")]
+    public IActionResult PUT_api_program_properties_ddbec910() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/program-properties/{id}")]
+    public IActionResult PUT_api_program_properties__id__6c094179() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/AvaTax")]
+    public IActionResult PUT_api_programs_AvaTax_4bb6e469() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/EdgeExpress")]
+    public IActionResult PUT_api_programs_EdgeExpress_f759e900() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/carecredit")]
+    public IActionResult PUT_api_programs_carecredit_6345642d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/carecredit/properties")]
+    public IActionResult PUT_api_programs_carecredit_properties_d2e170ee() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/payconnect/properties")]
+    public IActionResult PUT_api_programs_payconnect_properties_4882bd75() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/paysimple/properties")]
+    public IActionResult PUT_api_programs_paysimple_properties_1998229d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/podium/properties")]
+    public IActionResult PUT_api_programs_podium_properties_e55be1bb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/transworld")]
+    public IActionResult PUT_api_programs_transworld_32c6324a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/trojan-collect")]
+    public IActionResult PUT_api_programs_trojan_collect_5e1aa7b9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/xcharge/properties")]
+    public IActionResult PUT_api_programs_xcharge_properties_e414178a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/programs/xdr/properties")]
+    public IActionResult PUT_api_programs_xdr_properties_8fb17f4f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/providers/students/{id}")]
+    public IActionResult PUT_api_providers_students__id__b3e8c446() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/queries/{id}")]
+    public IActionResult PUT_api_queries__id__80b9cf55() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/question-defs/{id}")]
+    public IActionResult PUT_api_question_defs__id__9287d26c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/quickbooks/online/settings")]
+    public IActionResult PUT_api_quickbooks_online_settings_bce92729() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/quickbooks/settings")]
+    public IActionResult PUT_api_quickbooks_settings_8cfb941a() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/radiology/mount-defs/{id}")]
+    public IActionResult PUT_api_radiology_mount_defs__id__50dd7a67() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/radiology/mount-items/{id}")]
+    public IActionResult PUT_api_radiology_mount_items__id__39f1e9f5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/reactivation-rules/{id}")]
+    public IActionResult PUT_api_reactivation_rules__id__139ef3a5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/reactivations/{id}")]
+    public IActionResult PUT_api_reactivations__id__63a9890f() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/recall-types/{id}")]
+    public IActionResult PUT_api_recall_types__id__91740590() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/recalls/settings")]
+    public IActionResult PUT_api_recalls_settings_acb75998() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/recalls/{id}")]
+    public IActionResult PUT_api_recalls__id__138aa190() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/reconciles/{id}")]
+    public IActionResult PUT_api_reconciles__id__2bb8b8cd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/reference-entries/{id}")]
+    public IActionResult PUT_api_reference_entries__id__bf280449() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/references/{id}")]
+    public IActionResult PUT_api_references__id__bada3922() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/registration-keys/{id}")]
+    public IActionResult PUT_api_registration_keys__id__b81e5e51() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/reminder-rules/{id}")]
+    public IActionResult PUT_api_reminder_rules__id__da2cecd9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/repeat-charges/{id}")]
+    public IActionResult PUT_api_repeat_charges__id__4cf413fe() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/replication/servers/{id}")]
+    public IActionResult PUT_api_replication_servers__id__1c3927eb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/replication/settings")]
+    public IActionResult PUT_api_replication_settings_6b7de031() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/reports/setup")]
+    public IActionResult PUT_api_reports_setup_69f0d490() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/requests/{id}")]
+    public IActionResult PUT_api_requests__id__6f0f0c49() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/required-fields/{id}")]
+    public IActionResult PUT_api_required_fields__id__f9351545() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/requirements/{id}/students/{studentId}")]
+    public IActionResult PUT_api_requirements__id__students__studentId__53633332() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/resellers/{id}")]
+    public IActionResult PUT_api_resellers__id__23091d39() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/resellers/{id}/services/{serviceId}")]
+    public IActionResult PUT_api_resellers__id__services__serviceId__1d377e92() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/rx-alerts/{id}")]
+    public IActionResult PUT_api_rx_alerts__id__d8e469a1() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/scanner-settings")]
+    public IActionResult PUT_api_scanner_settings_8441c91b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/schedule-blocks/{id}")]
+    public IActionResult PUT_api_schedule_blocks__id__8b797300() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/schedule-days/{id}")]
+    public IActionResult PUT_api_schedule_days__id__bd4027ba() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/scheduled-processes/{id}")]
+    public IActionResult PUT_api_scheduled_processes__id__83093d1e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/schedules/{id}")]
+    public IActionResult PUT_api_schedules__id__d826bdc7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/school-classes/{id}")]
+    public IActionResult PUT_api_school_classes__id__ae52cab2() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/screen-groups/{id}")]
+    public IActionResult PUT_api_screen_groups__id__dcd49800() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/screens/{id}")]
+    public IActionResult PUT_api_screens__id__985e157c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/secure-email/settings")]
+    public IActionResult PUT_api_secure_email_settings_774cec43() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/security/global")]
+    public IActionResult PUT_api_security_global_78e85222() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sheet-defs/defaults")]
+    public IActionResult PUT_api_sheet_defs_defaults_b158d097() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sheet-defs/{id}")]
+    public IActionResult PUT_api_sheet_defs__id__6916e04e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sheet-field-defs/{id}")]
+    public IActionResult PUT_api_sheet_field_defs__id__61af9584() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sheet-fields/pat-image/{id}")]
+    public IActionResult PUT_api_sheet_fields_pat_image__id__6011f736() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sheet-fills/{id}")]
+    public IActionResult PUT_api_sheet_fills__id__5e885ee9() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sheets/output-format")]
+    public IActionResult PUT_api_sheets_output_format_c9134bbb() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sig-button-defs/{id}")]
+    public IActionResult PUT_api_sig_button_defs__id__4b2463bd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/sig-element-defs/{id}")]
+    public IActionResult PUT_api_sig_element_defs__id__40974e5c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/state-abbreviations/{id}")]
+    public IActionResult PUT_api_state_abbreviations__id__edf572ff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/statements/options")]
+    public IActionResult PUT_api_statements_options_41049423() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/summary-ccds/{id}")]
+    public IActionResult PUT_api_summary_ccds__id__ee57deac() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/suppliers/{id}")]
+    public IActionResult PUT_api_suppliers__id__9bfec0ec() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/supplies/{id}")]
+    public IActionResult PUT_api_supplies__id__b547c70e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/supply-orders/{id}")]
+    public IActionResult PUT_api_supply_orders__id__ca216ccd() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/supply-orders/{orderId}/items/{id}")]
+    public IActionResult PUT_api_supply_orders__orderId__items__id__31711432() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/task-lists/inbox")]
+    public IActionResult PUT_api_task_lists_inbox_7b7ea82d() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/task-lists/{id}")]
+    public IActionResult PUT_api_task_lists__id__7f3b586b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/tasks/{id}")]
+    public IActionResult PUT_api_tasks__id__46b285fc() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/tasks/{taskId}/notes/{id}")]
+    public IActionResult PUT_api_tasks__taskId__notes__id__3770af2b() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/testmode/overrides/{entity}")]
+    public IActionResult PUT_api_testmode_overrides__entity__d801aeff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/timeadjusts/{id}")]
+    public IActionResult PUT_api_timeadjusts__id__53d03367() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/timecardrules/{id}")]
+    public IActionResult PUT_api_timecardrules__id__ce76c891() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/transactions/{id}")]
+    public IActionResult PUT_api_transactions__id__17dfa0a8() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/treat-plans/{id}/signature")]
+    public IActionResult PUT_api_treat_plans__id__signature_ea310341() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/treatment-plans/{id}/procedures")]
+    public IActionResult PUT_api_treatment_plans__id__procedures_489d8a79() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/user-prefs/{userId}/AutoNoteExpandedCats")]
+    public IActionResult PUT_api_user_prefs__userId__AutoNoteExpandedCats_81492363() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/users/{id}")]
+    public IActionResult PUT_api_users__id__0d91542e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/vaccine-defs/{id}")]
+    public IActionResult PUT_api_vaccine_defs__id__a4029ff5() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/vaccine-observations/{id}")]
+    public IActionResult PUT_api_vaccine_observations__id__03377116() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/vital-signs/{id}")]
+    public IActionResult PUT_api_vital_signs__id__84f0f76c() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/web-browser/preferences")]
+    public IActionResult PUT_api_web_browser_preferences_3b59a9ff() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/web-forms/preferences")]
+    public IActionResult PUT_api_web_forms_preferences_3dbb4028() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/webchat/sessions/{id}")]
+    public IActionResult PUT_api_webchat_sessions__id__7c3e1b7e() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/webchat/sessions/{id}/notes/{noteId}")]
+    public IActionResult PUT_api_webchat_sessions__id__notes__noteId__a750b388() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/wiki/lists/{id}")]
+    public IActionResult PUT_api_wiki_lists__id__81a16d87() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/wiki/lists/{id}/headers")]
+    public IActionResult PUT_api_wiki_lists__id__headers_c6dd1f10() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/wiki/lists/{listId}/items/{itemId}")]
+    public IActionResult PUT_api_wiki_lists__listId__items__itemId__e1ebb679() => StatusCode(StatusCodes.Status501NotImplemented);
+
+    [HttpPut("/api/wiki/pages/{id}")]
+    public IActionResult PUT_api_wiki_pages__id__917dcde7() => StatusCode(StatusCodes.Status501NotImplemented);
+
+}

--- a/spec/form-api.json
+++ b/spec/form-api.json
@@ -1,0 +1,15978 @@
+[
+  {
+    "formPath": "OpenDental/Forms/FormASAP.cs",
+    "formName": "FormASAP",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appointments/asap",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recalls/asap",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recalls/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}/priority",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/sites",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched-asap/clinics",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched-asap/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/asap-comms/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAbout.cs",
+    "formName": "FormAbout",
+    "endpoints": [
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/{name}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/update-histories/version/{version}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computers/service-info",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submissions/diagnostics",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccountPick.cs",
+    "formName": "FormAccountPick",
+    "endpoints": [
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts/{id}/balance",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/quickbooks/accounts",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccounting.cs",
+    "formName": "FormAccounting",
+    "endpoints": [
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccountingAutoPayEdit.cs",
+    "formName": "FormAccountingAutoPayEdit",
+    "endpoints": [
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/payment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAccountingSetup.cs",
+    "formName": "FormAccountingSetup",
+    "endpoints": [
+      {
+        "path": "/api/prefs/AccountingDepositAccounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingDepositAccounts",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingIncomeAccount",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingIncomeAccount",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingCashIncomeAccount",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/AccountingCashIncomeAccount",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/accounting-auto-pays/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/payment-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormActivityLog.cs",
+    "formName": "FormActivityLog",
+    "endpoints": [
+      {
+        "path": "/api/eservice-logs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservice-actions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjMulti.cs",
+    "formName": "FormAdjMulti",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/adjustments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/program-properties",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjust.cs",
+    "formName": "FormAdjust",
+    "endpoints": [
+      {
+        "path": "/api/adjustments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/adjustment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjustSelect.cs",
+    "formName": "FormAdjustSelect",
+    "endpoints": [
+      {
+        "path": "/api/adjustments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdjustmentPicker.cs",
+    "formName": "FormAdjustmentPicker",
+    "endpoints": [
+      {
+        "path": "/api/adjustments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/adjustment-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPatientList.cs",
+    "formName": "FormAdvertisingPatientList",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPostcardsAccountSetup.cs",
+    "formName": "FormAdvertisingPostcardsAccountSetup",
+    "endpoints": [
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/sso",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPostcardsSend.cs",
+    "formName": "FormAdvertisingPostcardsSend",
+    "endpoints": [
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/sso",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/patient-lists",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAdvertisingPostcardsSetup.cs",
+    "formName": "FormAdvertisingPostcardsSetup",
+    "endpoints": [
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/advertising-postcards/accounts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/advertising-postcard-guid",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/advertising-postcard-guid",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAiChatSession.cs",
+    "formName": "FormAiChatSession",
+    "endpoints": [
+      {
+        "path": "/api/ai/assistants",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/end",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAlertCategorySetup.cs",
+    "formName": "FormAlertCategorySetup",
+    "endpoints": [
+      {
+        "path": "/api/alert-categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/alert-categories",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/alert-categories/{id}/links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/alert-categories/{id}/links",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAlerts.cs",
+    "formName": "FormAlerts",
+    "endpoints": [
+      {
+        "path": "/api/alerts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/alerts/{id}/read",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/alerts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllergyDefEdit.cs",
+    "formName": "FormAllergyDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/medications/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllergyEdit.cs",
+    "formName": "FormAllergyEdit",
+    "endpoints": [
+      {
+        "path": "/api/allergy-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/allergies",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/allergies/{allergyId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/allergies/{allergyId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllergySetup.cs",
+    "formName": "FormAllergySetup",
+    "endpoints": [
+      {
+        "path": "/api/allergy-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/allergy-defs/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAllocationsSetup.cs",
+    "formName": "FormAllocationsSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/pay-split-unearned-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAmountEdit.cs",
+    "formName": "FormAmountEdit",
+    "endpoints": [
+      {
+        "path": "/api/financial/amounts/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthElevateSecurityPriv.cs",
+    "formName": "FormAnesthElevateSecurityPriv",
+    "endpoints": [
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedDelDose.cs",
+    "formName": "FormAnesthMedDelDose",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications/{medId}/doses/{doseId}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{medId}/doses/{doseId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedSuppliers.cs",
+    "formName": "FormAnesthMedSuppliers",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedSuppliersEdit.cs",
+    "formName": "FormAnesthMedSuppliersEdit",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthMedsEdit.cs",
+    "formName": "FormAnesthMedsEdit",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/adjustments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnesthesiaScore.cs",
+    "formName": "FormAnesthesiaScore",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/anesthetic-records/{recordId}/score",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{recordId}/score",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{recordId}/score",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticMedsIntake.cs",
+    "formName": "FormAnestheticMedsIntake",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/med-suppliers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/quantity",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/intake",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticMedsInventory.cs",
+    "formName": "FormAnestheticMedsInventory",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticMedsWasteQty.cs",
+    "formName": "FormAnestheticMedsWasteQty",
+    "endpoints": [
+      {
+        "path": "/api/anesthesia/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthesia/medications/{id}/waste",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAnestheticRecord.cs",
+    "formName": "FormAnestheticRecord",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/anesthetic-records",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/medications",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/medications/{medId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/vitals",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/anesthetic-records/{id}/vitals",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptBreak.cs",
+    "formName": "FormApptBreak",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptConflicts.cs",
+    "formName": "FormApptConflicts",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptEdit.cs",
+    "formName": "FormApptEdit",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recalls/{patientId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptEditOld.cs",
+    "formName": "FormApptEditOld",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptFieldDefs.cs",
+    "formName": "FormApptFieldDefs",
+    "endpoints": [
+      {
+        "path": "/api/appt-field-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-field-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-field-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-field-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptPrintSetup.cs",
+    "formName": "FormApptPrintSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptProcs.cs",
+    "formName": "FormApptProcs",
+    "endpoints": [
+      {
+        "path": "/api/procedures",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptReminderRuleAggEdit.cs",
+    "formName": "FormApptReminderRuleAggEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptReminderRuleEdit.cs",
+    "formName": "FormApptReminderRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-reminder-rules/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptRules.cs",
+    "formName": "FormApptRules",
+    "endpoints": [
+      {
+        "path": "/api/appt-rules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-rules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-rules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptSearchAdvanced.cs",
+    "formName": "FormApptSearchAdvanced",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/search",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/schedule-openings",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptTypeEdit.cs",
+    "formName": "FormApptTypeEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptTypes.cs",
+    "formName": "FormApptTypes",
+    "endpoints": [
+      {
+        "path": "/api/appt-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/appt-types/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptViewEdit.cs",
+    "formName": "FormApptViewEdit",
+    "endpoints": [
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptViewEditMobile.cs",
+    "formName": "FormApptViewEditMobile",
+    "endpoints": [
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptViews.cs",
+    "formName": "FormApptViews",
+    "endpoints": [
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/appt-views/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormApptsOther.cs",
+    "formName": "FormApptsOther",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/family",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/appointments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/recalls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormArManager.cs",
+    "formName": "FormArManager",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ar-manager/patient-aging/unsent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patient-aging/sent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patient-aging/excluded",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patients/{id}/placements",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ar-manager/patients/{id}/status",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAsapSetup.cs",
+    "formName": "FormAsapSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAudit.cs",
+    "formName": "FormAudit",
+    "endpoints": [
+      {
+        "path": "/api/security-logs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAuditOrtho.cs",
+    "formName": "FormAuditOrtho",
+    "endpoints": [
+      {
+        "path": "/api/security-logs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoCode.cs",
+    "formName": "FormAutoCode",
+    "endpoints": [
+      {
+        "path": "/api/auto-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-codes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-codes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoCodeEdit.cs",
+    "formName": "FormAutoCodeEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-codes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-codes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items?autoCodeId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoCommExclusionDays.cs",
+    "formName": "FormAutoCommExclusionDays",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/auto-comm-exclude-dates?clinicId={clinicId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-comm-exclude-dates",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-comm-exclude-dates/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDays",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDays",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDaysUseHQ",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/EConfirmExcludeDaysUseHQ",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoItemEdit.cs",
+    "formName": "FormAutoItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-code-items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-items/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-conds?autoCodeItemId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-conds?autoCodeItemId={id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-code-conds",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteControlEdit.cs",
+    "formName": "FormAutoNoteControlEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-note-controls",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteControls.cs",
+    "formName": "FormAutoNoteControls",
+    "endpoints": [
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteEdit.cs",
+    "formName": "FormAutoNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs?autoNoteId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteExport.cs",
+    "formName": "FormAutoNoteExport",
+    "endpoints": [
+      {
+        "path": "/api/auto-notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/export",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNoteResponsePicker.cs",
+    "formName": "FormAutoNoteResponsePicker",
+    "endpoints": [
+      {
+        "path": "/api/auto-notes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutoNotes.cs",
+    "formName": "FormAutoNotes",
+    "endpoints": [
+      {
+        "path": "/api/auto-notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-note-controls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/auto-notes/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/user-prefs/{userId}/AutoNoteExpandedCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/user-prefs/{userId}/AutoNoteExpandedCats",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutomation.cs",
+    "formName": "FormAutomation",
+    "endpoints": [
+      {
+        "path": "/api/automations",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automations",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutomationConditionEdit.cs",
+    "formName": "FormAutomationConditionEdit",
+    "endpoints": [
+      {
+        "path": "/api/automation-conditions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automation-conditions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/automation-conditions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/automation-conditions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/billing-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAutomationEdit.cs",
+    "formName": "FormAutomationEdit",
+    "endpoints": [
+      {
+        "path": "/api/automations/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}/conditions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/automations/{id}/conditions",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/comm-log-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormAvaTax.cs",
+    "formName": "FormAvaTax",
+    "endpoints": [
+      {
+        "path": "/api/programs/AvaTax",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/AvaTax",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=AvaTax",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=AvaTax",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/adj-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/pat-field-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBackup.cs",
+    "formName": "FormBackup",
+    "endpoints": [
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitEdit.cs",
+    "formName": "FormBenefitEdit",
+    "endpoints": [
+      {
+        "path": "/api/benefits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/covcats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitElectHistory.cs",
+    "formName": "FormBenefitElectHistory",
+    "endpoints": [
+      {
+        "path": "/api/etrans/270?planNum={planNum}&subNum={subNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitFrequencies.cs",
+    "formName": "FormBenefitFrequencies",
+    "endpoints": [
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBenefitFrequencyEdit.cs",
+    "formName": "FormBenefitFrequencyEdit",
+    "endpoints": [
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/benefits/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBilling.cs",
+    "formName": "FormBilling",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/email-addresses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/statements",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/statements/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/statements",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBillingDefaults.cs",
+    "formName": "FormBillingDefaults",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ebills",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ebills",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBillingOptions.cs",
+    "formName": "FormBillingOptions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinic-prefs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/billing-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-filing-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/dunnings",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBillingTypeMerge.cs",
+    "formName": "FormBillingTypeMerge",
+    "endpoints": [
+      {
+        "path": "/api/definitions/billing-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/billing-types/{fromId}/merge/{intoId}",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBlockoutCutCopyPaste.cs",
+    "formName": "FormBlockoutCutCopyPaste",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/blockouts",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/blockouts/copy",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBlockoutDuplicatesFix.cs",
+    "formName": "FormBlockoutDuplicatesFix",
+    "endpoints": [
+      {
+        "path": "/api/blockouts/duplicates/count",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/blockouts/duplicates",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBugSubmission.cs",
+    "formName": "FormBugSubmission",
+    "endpoints": [
+      {
+        "path": "/api/bug-submissions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/bugs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bugs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/job-links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/jobs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBugSubmissionHashVitals.cs",
+    "formName": "FormBugSubmissionHashVitals",
+    "endpoints": [
+      {
+        "path": "/api/bug-submission-hashes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bugs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/registration-keys/patients",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormBugSubmissions.cs",
+    "formName": "FormBugSubmissions",
+    "endpoints": [
+      {
+        "path": "/api/bug-submissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submissions",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/bug-submission-hashes",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/bugs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/jobs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCCDPrint.cs",
+    "formName": "FormCCDPrint",
+    "endpoints": [
+      {
+        "path": "/api/etrans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/{id}/message-text",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insplans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/inssubs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claimprocs?claimId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/procedures",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCDSILabResult.cs",
+    "formName": "FormCDSILabResult",
+    "endpoints": [
+      {
+        "path": "/api/ucums",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/loincs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomeds",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCDSIntervention.cs",
+    "formName": "FormCDSIntervention",
+    "endpoints": [
+      {
+        "path": "/api/cds/interventions?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds/permissions/{userId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/knowledge-requests",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCDSSetup.cs",
+    "formName": "FormCDSSetup",
+    "endpoints": [
+      {
+        "path": "/api/cds/permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds/permissions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/usergroups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCalendar.cs",
+    "formName": "FormCalendar",
+    "endpoints": [
+      {
+        "path": "/api/calendar",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCanadaOutstandingTransactions.cs",
+    "formName": "FormCanadaOutstandingTransactions",
+    "endpoints": [
+      {
+        "path": "/api/carriers?canadianSupportedTypes=RequestForOutstandingTrans_04",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/canadian/outstanding-transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCanadaPaymentReconciliation.cs",
+    "formName": "FormCanadaPaymentReconciliation",
+    "endpoints": [
+      {
+        "path": "/api/carriers?supportsPaymentReconciliation=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences/PracticeDefaultProv",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/canadian/payment-reconciliations",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCanadaSummaryReconciliation.cs",
+    "formName": "FormCanadaSummaryReconciliation",
+    "endpoints": [
+      {
+        "path": "/api/canadian-networks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers?supportsSummaryReconciliation=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/PracticeDefaultProv",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/canadian/summary-reconciliations",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCredit.cs",
+    "formName": "FormCareCredit",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/carecredit/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patfielddefs/carecredit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/patfields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/applications",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/lookups",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/admin",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/reports",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCreditSetup.cs",
+    "formName": "FormCareCreditSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/carecredit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/carecredit",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/carecredit/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/carecredit/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patfielddefs?type=CareCredit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs?category=PaymentTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providerclinics",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCreditTransactions.cs",
+    "formName": "FormCareCreditTransactions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/carecredit/transactions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions/{id}/acknowledge",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions/{id}/refund",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carecredit/transactions/{id}/reprocess",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients?ids={ids}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCareCreditWeb.cs",
+    "formName": "FormCareCreditWeb",
+    "endpoints": [
+      {
+        "path": "/api/carecredit/sessions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCarrierCombine.cs",
+    "formName": "FormCarrierCombine",
+    "endpoints": [
+      {
+        "path": "/api/carriers?ids={ids}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCarrierEdit.cs",
+    "formName": "FormCarrierEdit",
+    "endpoints": [
+      {
+        "path": "/api/defs?category=CarrierGroupNames",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/canadiannetworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}/dependent-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCarriers.cs",
+    "formName": "FormCarriers",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses/default",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/combine",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ItransImportFields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ItransImportFields",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/itrans/carriers/update",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCdsTriggerEdit.cs",
+    "formName": "FormCdsTriggerEdit",
+    "endpoints": [
+      {
+        "path": "/api/preferences/SoftwareName",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users/{id}/cds-permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/diseasedefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd9/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd10/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomeds/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medications/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/rxnorms/{rxCui}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cvxs/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/allergydefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/loincs/{code}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCdsTriggers.cs",
+    "formName": "FormCdsTriggers",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}/cds-permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cds-triggers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr-measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertEmployee.cs",
+    "formName": "FormCertEmployee",
+    "endpoints": [
+      {
+        "path": "/api/employees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertificationEdit.cs",
+    "formName": "FormCertificationEdit",
+    "endpoints": [
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/certs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/certs?includeHidden=true",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertificationSetup.cs",
+    "formName": "FormCertificationSetup",
+    "endpoints": [
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs?categoryId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/certs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/certs/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCertifications.cs",
+    "formName": "FormCertifications",
+    "endpoints": [
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/defs?category=CertificationCategories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/certs?includeHidden=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cert-employees?employeeId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChangeCloudPassword.cs",
+    "formName": "FormChangeCloudPassword",
+    "endpoints": [
+      {
+        "path": "/api/cloud/password",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/CloudPasswordNeedsReset",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChartView.cs",
+    "formName": "FormChartView",
+    "endpoints": [
+      {
+        "path": "/api/chart-views/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}/display-fields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}/display-fields",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/chart-views/{id}/display-fields",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChartViewDateFilter.cs",
+    "formName": "FormChartViewDateFilter",
+    "endpoints": [
+      {
+        "path": "/api/chart-views/filter",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormChooseDatabase.cs",
+    "formName": "FormChooseDatabase",
+    "endpoints": [
+      {
+        "path": "/api/central-connections/computer-names",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/central-connections/databases",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/central-connections/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachHistory.cs",
+    "formName": "FormClaimAttachHistory",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments/{attachId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachPasteDXC.cs",
+    "formName": "FormClaimAttachPasteDXC",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=ImageCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachPasteDXCItem.cs",
+    "formName": "FormClaimAttachPasteDXCItem",
+    "endpoints": [
+      {
+        "path": "/api/claim-attachments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachSnipDXC.cs",
+    "formName": "FormClaimAttachSnipDXC",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=ImageCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachment.cs",
+    "formName": "FormClaimAttachment",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/definitions?category=ImageCats",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments/{attachId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimAttachmentItemEdit.cs",
+    "formName": "FormClaimAttachmentItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-attachments/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-attachments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimCreate.cs",
+    "formName": "FormClaimCreate",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/family",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/pat-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/inssubs?family={familyId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimCustomTrackingUpdate.cs",
+    "formName": "FormClaimCustomTrackingUpdate",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=ClaimCustomTracking",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimErrorCode",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/trackings",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/trackings/{trackingId}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimEdit.cs",
+    "formName": "FormClaimEdit",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/family",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimCustomTracking",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/attachments/{attachId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimFormEdit.cs",
+    "formName": "FormClaimFormEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}/items/{itemId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimFormItemEdit.cs",
+    "formName": "FormClaimFormItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-form-items/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimForms.cs",
+    "formName": "FormClaimForms",
+    "endpoints": [
+      {
+        "path": "/api/claim-forms/internal",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimInstEdit.cs",
+    "formName": "FormClaimInstEdit",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimOverpay.cs",
+    "formName": "FormClaimOverpay",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayBatch.cs",
+    "formName": "FormClaimPayBatch",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}/claims",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-pay-splits/outstanding",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayEdit.cs",
+    "formName": "FormClaimPayEdit",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=InsurancePaymentType",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimPaymentGroups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/required-fields?type=InsPayEdit",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayEditOld.cs",
+    "formName": "FormClaimPayEditOld",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/pay-splits",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayList.cs",
+    "formName": "FormClaimPayList",
+    "endpoints": [
+      {
+        "path": "/api/claim-payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimPaymentGroups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayPreAuth.cs",
+    "formName": "FormClaimPayPreAuth",
+    "endpoints": [
+      {
+        "path": "/api/procedures?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPayTotal.cs",
+    "formName": "FormClaimPayTotal",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ClaimPaymentTracking",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimPrint.cs",
+    "formName": "FormClaimPrint",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/procedures?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-forms/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/carriers/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimProc.cs",
+    "formName": "FormClaimProc",
+    "endpoints": [
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-procs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimProcBlueBookLog.cs",
+    "formName": "FormClaimProcBlueBookLog",
+    "endpoints": [
+      {
+        "path": "/api/claim-procs/{id}/bluebook-logs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimReports.cs",
+    "formName": "FormClaimReports",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}/retrieve-reports",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimResend.cs",
+    "formName": "FormClaimResend",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/resend",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClaimsSend.cs",
+    "formName": "FormClaimsSend",
+    "endpoints": [
+      {
+        "path": "/api/claims/queue",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/validate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/{id}/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}/retrieve-reports",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/claims/history",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/definitions?category=ClaimCustomTracking",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClearinghouseEdit.cs",
+    "formName": "FormClearinghouseEdit",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClearinghouses.cs",
+    "formName": "FormClearinghouses",
+    "endpoints": [
+      {
+        "path": "/api/clearinghouses",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clearinghouses/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/prefs/ClaimReportComputerName",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportComputerName",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveInterval",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveInterval",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveTime",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceiveTime",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceivedByService",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClaimReportReceivedByService",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultDent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultDent",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultMed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultMed",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultEligibility",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/ClearinghouseDefaultEligibility",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClinicEdit.cs",
+    "formName": "FormClinicEdit",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClinics.cs",
+    "formName": "FormClinics",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormClockEventEdit.cs",
+    "formName": "FormClockEventEdit",
+    "endpoints": [
+      {
+        "path": "/api/clock-events/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clock-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clock-events/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clock-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloneAdd.cs",
+    "formName": "FormCloneAdd",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patient-clones",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudManagement.cs",
+    "formName": "FormCloudManagement",
+    "endpoints": [
+      {
+        "path": "/api/cloud/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud/sessions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud/sessions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudSessionLimit.cs",
+    "formName": "FormCloudSessionLimit",
+    "endpoints": [
+      {
+        "path": "/api/cloud/accounts/{id}/session-limit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud/accounts/{id}/session-limit",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudUserEdit.cs",
+    "formName": "FormCloudUserEdit",
+    "endpoints": [
+      {
+        "path": "/api/cloud-users/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud-users",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud-users/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/cloud-users/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCloudUsers.cs",
+    "formName": "FormCloudUsers",
+    "endpoints": [
+      {
+        "path": "/api/cloud-users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCodeGroupEdit.cs",
+    "formName": "FormCodeGroupEdit",
+    "endpoints": [
+      {
+        "path": "/api/code-groups/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/code-groups/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCodeGroups.cs",
+    "formName": "FormCodeGroups",
+    "endpoints": [
+      {
+        "path": "/api/code-groups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCodeSystemsImport.cs",
+    "formName": "FormCodeSystemsImport",
+    "endpoints": [
+      {
+        "path": "/api/code-systems/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCommPrefPicker.cs",
+    "formName": "FormCommPrefPicker",
+    "endpoints": [
+      {
+        "path": "/api/communication-preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/communication-preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormComputers.cs",
+    "formName": "FormComputers",
+    "endpoints": [
+      {
+        "path": "/api/computers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/computers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/computers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormConfirmList.cs",
+    "formName": "FormConfirmList",
+    "endpoints": [
+      {
+        "path": "/api/appointments/confirm-list",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}/confirmation",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormConfirmationsSetup.cs",
+    "formName": "FormConfirmationsSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences/confirmation",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/confirmation",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormConnectionLost.cs",
+    "formName": "FormConnectionLost",
+    "endpoints": [
+      {
+        "path": "/api/connections/status",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormContactEdit.cs",
+    "formName": "FormContactEdit",
+    "endpoints": [
+      {
+        "path": "/api/contacts/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormContacts.cs",
+    "formName": "FormContacts",
+    "endpoints": [
+      {
+        "path": "/api/contacts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/contacts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormContinuityOfCareDocument.cs",
+    "formName": "FormContinuityOfCareDocument",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/ccd",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/ccd",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCounties.cs",
+    "formName": "FormCounties",
+    "endpoints": [
+      {
+        "path": "/api/counties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/counties",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/counties/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/counties/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCpts.cs",
+    "formName": "FormCpts",
+    "endpoints": [
+      {
+        "path": "/api/cpts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/cpts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/cpts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/cpts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditCardEdit.cs",
+    "formName": "FormCreditCardEdit",
+    "endpoints": [
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditCardManage.cs",
+    "formName": "FormCreditCardManage",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/credit-cards",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditRecurringCharges.cs",
+    "formName": "FormCreditRecurringCharges",
+    "endpoints": [
+      {
+        "path": "/api/credit-recurring-charges",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-recurring-charges/run",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCreditRecurringDateChoose.cs",
+    "formName": "FormCreditRecurringDateChoose",
+    "endpoints": [
+      {
+        "path": "/api/credit-recurring-charges/dates",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCustomerManagement.cs",
+    "formName": "FormCustomerManagement",
+    "endpoints": [
+      {
+        "path": "/api/registration-keys",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormCvx.cs",
+    "formName": "FormCvx",
+    "endpoints": [
+      {
+        "path": "/api/cvxs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDashboardWidgetSetup.cs",
+    "formName": "FormDashboardWidgetSetup",
+    "endpoints": [
+      {
+        "path": "/api/user-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/group-permissions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/group-permissions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-field-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDashboardWidgets.cs",
+    "formName": "FormDashboardWidgets",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDatabaseMaintTemp.cs",
+    "formName": "FormDatabaseMaintTemp",
+    "endpoints": [
+      {
+        "path": "/api/database-maintenance/database-names",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/duplicate-claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/duplicate-supplemental-payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/missing-claim-procs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/fix-claimproc-duplicates",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/fix-missing-claim-procs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/backup",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDatabaseMaintenance.cs",
+    "formName": "FormDatabaseMaintenance",
+    "endpoints": [
+      {
+        "path": "/api/database-maintenance/methods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/run",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UpdateInProgressOnComputerName",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UpdateInProgressOnComputerName",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/DatabaseMaintenanceSkipCheckTable",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/DatabaseMaintenanceSkipCheckTable",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDatabaseMaintenancePat.cs",
+    "formName": "FormDatabaseMaintenancePat",
+    "endpoints": [
+      {
+        "path": "/api/database-maintenance/patient-methods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/database-maintenance/patient-run",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEdit.cs",
+    "formName": "FormDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEditBlockout.cs",
+    "formName": "FormDefEditBlockout",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEditImages.cs",
+    "formName": "FormDefEditImages",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/TaskAttachmentCategory",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/TaskAttachmentCategory",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefEditWebSchedApptTypes.cs",
+    "formName": "FormDefEditWebSchedApptTypes",
+    "endpoints": [
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/appointment-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/def-links",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/def-links",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefaultCCProcs.cs",
+    "formName": "FormDefaultCCProcs",
+    "endpoints": [
+      {
+        "path": "/api/preferences/DefaultCCProcs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/DefaultCCProcs",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/default-procs-sync",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefinitionPicker.cs",
+    "formName": "FormDefinitionPicker",
+    "endpoints": [
+      {
+        "path": "/api/definitions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDefinitions.cs",
+    "formName": "FormDefinitions",
+    "endpoints": [
+      {
+        "path": "/api/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDentalSchoolSetup.cs",
+    "formName": "FormDentalSchoolSetup",
+    "endpoints": [
+      {
+        "path": "/api/user-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/SecurityGroupForStudents",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/SecurityGroupForInstructors",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/users/dental-schools/update-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDepositEdit.cs",
+    "formName": "FormDepositEdit",
+    "endpoints": [
+      {
+        "path": "/api/deposits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/claim-payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=AutoDeposit",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=PaymentTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=InsurancePaymentType",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDeposits.cs",
+    "formName": "FormDeposits",
+    "endpoints": [
+      {
+        "path": "/api/deposits",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences/PracticeBankNumber",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlanEdit.cs",
+    "formName": "FormDiscountPlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=AdjTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}/patients",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}/patients/count",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlanMerge.cs",
+    "formName": "FormDiscountPlanMerge",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{from}/merge/{to}",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlanSubEdit.cs",
+    "formName": "FormDiscountPlanSubEdit",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plan-subs/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/commlogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiscountPlans.cs",
+    "formName": "FormDiscountPlans",
+    "endpoints": [
+      {
+        "path": "/api/discount-plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/discount-plans/{id}/patients/count",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=AdjTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiseaseDefEdit.cs",
+    "formName": "FormDiseaseDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/disease-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDiseaseDefs.cs",
+    "formName": "FormDiseaseDefs",
+    "endpoints": [
+      {
+        "path": "/api/disease-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/disease-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDispensary.cs",
+    "formName": "FormDispensary",
+    "endpoints": [
+      {
+        "path": "/api/disp-supplies",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldCategories.cs",
+    "formName": "FormDisplayFieldCategories",
+    "endpoints": [
+      {
+        "path": "/api/display-field-categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/display-field-categories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldEdit.cs",
+    "formName": "FormDisplayFieldEdit",
+    "endpoints": [
+      {
+        "path": "/api/display-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldOrthoEdit.cs",
+    "formName": "FormDisplayFieldOrthoEdit",
+    "endpoints": [
+      {
+        "path": "/api/display-fields/ortho/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFields.cs",
+    "formName": "FormDisplayFields",
+    "endpoints": [
+      {
+        "path": "/api/display-fields",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDisplayFieldsOrthoChart.cs",
+    "formName": "FormDisplayFieldsOrthoChart",
+    "endpoints": [
+      {
+        "path": "/api/display-fields/ortho",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDomainUserPick.cs",
+    "formName": "FormDomainUserPick",
+    "endpoints": [
+      {
+        "path": "/api/domain-users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDoseSpotAssignClinicId.cs",
+    "formName": "FormDoseSpotAssignClinicId",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDoseSpotAssignUserId.cs",
+    "formName": "FormDoseSpotAssignUserId",
+    "endpoints": [
+      {
+        "path": "/api/dosespot/users/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDoseSpotProperyEdit.cs",
+    "formName": "FormDoseSpotProperyEdit",
+    "endpoints": [
+      {
+        "path": "/api/dosespot/properties/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDropboxAuthorize.cs",
+    "formName": "FormDropboxAuthorize",
+    "endpoints": [
+      {
+        "path": "/api/dropbox/authorize",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDrugManufacturerSetup.cs",
+    "formName": "FormDrugManufacturerSetup",
+    "endpoints": [
+      {
+        "path": "/api/drug-manufacturers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDrugUnitSetup.cs",
+    "formName": "FormDrugUnitSetup",
+    "endpoints": [
+      {
+        "path": "/api/drug-units",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDunningEdit.cs",
+    "formName": "FormDunningEdit",
+    "endpoints": [
+      {
+        "path": "/api/dunning-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormDunningSetup.cs",
+    "formName": "FormDunningSetup",
+    "endpoints": [
+      {
+        "path": "/api/dunning-messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/dunning-messages",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClinicalWorks.cs",
+    "formName": "FormEClinicalWorks",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardDefs.cs",
+    "formName": "FormEClipboardDefs",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/definitions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardImageCaptureDefEdit.cs",
+    "formName": "FormEClipboardImageCaptureDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/imagecapturedefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/imagecapturedefs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/imagecapturedefs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardImageCaptureDefs.cs",
+    "formName": "FormEClipboardImageCaptureDefs",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/imagecapturedefs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/imagecapturedefs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardImagePicker.cs",
+    "formName": "FormEClipboardImagePicker",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/images",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardSheetRule.cs",
+    "formName": "FormEClipboardSheetRule",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/sheetrules/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/sheetrules/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEClipboardSheetRules.cs",
+    "formName": "FormEClipboardSheetRules",
+    "endpoints": [
+      {
+        "path": "/api/eclipboards/sheetrules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/sheetrules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eclipboards/sheetrules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEHR.cs",
+    "formName": "FormEHR",
+    "endpoints": [
+      {
+        "path": "/api/ehr/patients/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERouting.cs",
+    "formName": "FormERouting",
+    "endpoints": [
+      {
+        "path": "/api/eroutings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutings/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERoutingDefEdit.cs",
+    "formName": "FormERoutingDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/eroutingdefs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutingdefs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutingdefs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutingdefs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERoutingDefs.cs",
+    "formName": "FormERoutingDefs",
+    "endpoints": [
+      {
+        "path": "/api/eroutingdefs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormERoutings.cs",
+    "formName": "FormERoutings",
+    "endpoints": [
+      {
+        "path": "/api/eroutings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eroutings/{id}/acknowledge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServices2FactorAuthentication.cs",
+    "formName": "FormEServices2FactorAuthentication",
+    "endpoints": [
+      {
+        "path": "/api/eservices/2fa/send",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/2fa/verify",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesAutoMsging.cs",
+    "formName": "FormEServicesAutoMsging",
+    "endpoints": [
+      {
+        "path": "/api/eservices/automessages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/automessages/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesAutoMsgingAdvanced.cs",
+    "formName": "FormEServicesAutoMsgingAdvanced",
+    "endpoints": [
+      {
+        "path": "/api/eservices/automessages/advanced",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/automessages/advanced",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesAutoMsgingPreferences.cs",
+    "formName": "FormEServicesAutoMsgingPreferences",
+    "endpoints": [
+      {
+        "path": "/api/eservices/automessages/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/automessages/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesEClipboard.cs",
+    "formName": "FormEServicesEClipboard",
+    "endpoints": [
+      {
+        "path": "/api/eservices/eclipboard/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/eclipboard/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesEConnector.cs",
+    "formName": "FormEServicesEConnector",
+    "endpoints": [
+      {
+        "path": "/api/eservices/econnector/status",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/econnector/restart",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMisc.cs",
+    "formName": "FormEServicesMisc",
+    "endpoints": [
+      {
+        "path": "/api/eservices/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMobileAppDeviceManage.cs",
+    "formName": "FormEServicesMobileAppDeviceManage",
+    "endpoints": [
+      {
+        "path": "/api/eservices/mobileapp/devices",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/mobileapp/devices/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMobileSettings.cs",
+    "formName": "FormEServicesMobileSettings",
+    "endpoints": [
+      {
+        "path": "/api/eservices/mobile/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/mobile/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesMobileWeb.cs",
+    "formName": "FormEServicesMobileWeb",
+    "endpoints": [
+      {
+        "path": "/api/eservices/mobileweb/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/mobileweb/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesPatientPortal.cs",
+    "formName": "FormEServicesPatientPortal",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesSetup.cs",
+    "formName": "FormEServicesSetup",
+    "endpoints": [
+      {
+        "path": "/api/eservices/setup",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesSignup.cs",
+    "formName": "FormEServicesSignup",
+    "endpoints": [
+      {
+        "path": "/api/eservices/signup",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesTexting.cs",
+    "formName": "FormEServicesTexting",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/eservices/texting/usage",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedAdvanced.cs",
+    "formName": "FormEServicesWebSchedAdvanced",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/eservices/signups?service=WebSched",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched/hostedurls",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/eservices/websched/hostedurls/{clinicId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedNotify.cs",
+    "formName": "FormEServicesWebSchedNotify",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinic-prefs/{clinicId}/{prefName}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedPat.cs",
+    "formName": "FormEServicesWebSchedPat",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/eservices/signups?service=WebSchedNewPatAppt",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ApptConfirmed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=BlockoutTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEServicesWebSchedRecall.cs",
+    "formName": "FormEServicesWebSchedRecall",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recall-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ApptConfirmed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEcwDiag.cs",
+    "formName": "FormEcwDiag",
+    "endpoints": [
+      {
+        "path": "/api/programs/eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ecw/diagnostics",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEcwDiagAdv.cs",
+    "formName": "FormEcwDiagAdv",
+    "endpoints": [
+      {
+        "path": "/api/programs/eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=eclinicalworks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ecw/diagnostics/query",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEdgeExpressSetup.cs",
+    "formName": "FormEdgeExpressSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/EdgeExpress",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=EdgeExpress",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/definitions?category=PaymentTypes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEdgeExpressTrans.cs",
+    "formName": "FormEdgeExpressTrans",
+    "endpoints": [
+      {
+        "path": "/api/programs/EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=EdgeExpress",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/StoreCCtokens",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/edgeexpress/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEditTestModeOverrides.cs",
+    "formName": "FormEditTestModeOverrides",
+    "endpoints": [
+      {
+        "path": "/api/testmode/overrides/{entity}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/testmode/overrides/{entity}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEduResourceEdit.cs",
+    "formName": "FormEduResourceEdit",
+    "endpoints": [
+      {
+        "path": "/api/edu-resources/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/edu-resources",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/edu-resources/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/edu-resources/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/disease-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEduResourceSetup.cs",
+    "formName": "FormEduResourceSetup",
+    "endpoints": [
+      {
+        "path": "/api/edu-resources",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAmendmentEdit.cs",
+    "formName": "FormEhrAmendmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/amendments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAmendments.cs",
+    "formName": "FormEhrAmendments",
+    "endpoints": [
+      {
+        "path": "/api/ehr/amendments?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/amendments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAptObsEdit.cs",
+    "formName": "FormEhrAptObsEdit",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/loinc",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd9",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd10",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ucum-codes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrAptObses.cs",
+    "formName": "FormEhrAptObses",
+    "endpoints": [
+      {
+        "path": "/api/ehr/apt-observations?appointmentId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/apt-observations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/{prefName}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrCarePlanEdit.cs",
+    "formName": "FormEhrCarePlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/care-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrCarePlans.cs",
+    "formName": "FormEhrCarePlans",
+    "endpoints": [
+      {
+        "path": "/api/ehr/care-plans?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/care-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrClinicalSummary.cs",
+    "formName": "FormEhrClinicalSummary",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrEduBrowser.cs",
+    "formName": "FormEhrEduBrowser",
+    "endpoints": [
+      {
+        "path": "/api/ehr/education-resources",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrEduResourcesPat.cs",
+    "formName": "FormEhrEduResourcesPat",
+    "endpoints": [
+      {
+        "path": "/api/education-resources/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events?patientId={id}&type=EducationProvided",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrElectronicCopy.cs",
+    "formName": "FormEhrElectronicCopy",
+    "endpoints": [
+      {
+        "path": "/api/measure-events?patientId={id}&types=ElectronicCopyRequested,ElectronicCopyProvided",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/ccd/electronic-copy?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrEncryption.cs",
+    "formName": "FormEhrEncryption",
+    "endpoints": [
+      {
+        "path": "/api/email/test-encryption",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrExportCCD.cs",
+    "formName": "FormEhrExportCCD",
+    "endpoints": [
+      {
+        "path": "/api/ehr/ccd/summary",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrGrowthCharts.cs",
+    "formName": "FormEhrGrowthCharts",
+    "endpoints": [
+      {
+        "path": "/api/vitalsigns/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrHash.cs",
+    "formName": "FormEhrHash",
+    "endpoints": [
+      {
+        "path": "/api/email/test-hash",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabImageEdit.cs",
+    "formName": "FormEhrLabImageEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/documents",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/{labId}/images",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/{labId}/images",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabNoteEdit.cs",
+    "formName": "FormEhrLabNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-notes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-notes/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabOrderEdit2014.cs",
+    "formName": "FormEhrLabOrderEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/labs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results?labId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabOrderImport.cs",
+    "formName": "FormEhrLabOrderImport",
+    "endpoints": [
+      {
+        "path": "/api/ehr/labs/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabOrders.cs",
+    "formName": "FormEhrLabOrders",
+    "endpoints": [
+      {
+        "path": "/api/ehr/labs?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/labs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabPanelEdit.cs",
+    "formName": "FormEhrLabPanelEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-panels/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-panels/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results?panelId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabPanelImport.cs",
+    "formName": "FormEhrLabPanelImport",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-panels/import",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-panels/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabPanels.cs",
+    "formName": "FormEhrLabPanels",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-panels?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabResultEdit.cs",
+    "formName": "FormEhrLabResultEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabResultEdit2014.cs",
+    "formName": "FormEhrLabResultEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-results/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrLabSpecimenEdit.cs",
+    "formName": "FormEhrLabSpecimenEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/lab-specimens/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/lab-specimens/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMeasureEventEdit.cs",
+    "formName": "FormEhrMeasureEventEdit",
+    "endpoints": [
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMeasureEvents.cs",
+    "formName": "FormEhrMeasureEvents",
+    "endpoints": [
+      {
+        "path": "/api/measure-events?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMedicalOrderLabEdit.cs",
+    "formName": "FormEhrMedicalOrderLabEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-panels?orderId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMedicalOrderRadEdit.cs",
+    "formName": "FormEhrMedicalOrderRadEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/medical-orders/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrMedicalOrders.cs",
+    "formName": "FormEhrMedicalOrders",
+    "endpoints": [
+      {
+        "path": "/api/medical-orders?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrNotPerformed.cs",
+    "formName": "FormEhrNotPerformed",
+    "endpoints": [
+      {
+        "path": "/api/ehr/not-performed?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrNotPerformedEdit.cs",
+    "formName": "FormEhrNotPerformedEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/not-performed/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/codes/value-sets/{oid}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatListElementEdit.cs",
+    "formName": "FormEhrPatListElementEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-list-elements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-list-elements",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-list-elements/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-list-elements/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatListResults.cs",
+    "formName": "FormEhrPatListResults",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/query",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientConfidentialPrefEdit.cs",
+    "formName": "FormEhrPatientConfidentialPrefEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientExport.cs",
+    "formName": "FormEhrPatientExport",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientSelectSimple.cs",
+    "formName": "FormEhrPatientSelectSimple",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrPatientSmoking.cs",
+    "formName": "FormEhrPatientSmoking",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProvKeyEditCust.cs",
+    "formName": "FormEhrProvKeyEditCust",
+    "endpoints": [
+      {
+        "path": "/api/ehr/provider-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProvKeysCustomer.cs",
+    "formName": "FormEhrProvKeysCustomer",
+    "endpoints": [
+      {
+        "path": "/api/ehr/provider-keys",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProviderKeyEdit.cs",
+    "formName": "FormEhrProviderKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrProviderKeys.cs",
+    "formName": "FormEhrProviderKeys",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasureEdit.cs",
+    "formName": "FormEhrQualityMeasureEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quality-measures/{id}?startDate={dateStart}&endDate={dateEnd}&provId={provId}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasureEdit2014.cs",
+    "formName": "FormEhrQualityMeasureEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quality-measures/{id}?startDate={dateStart}&endDate={dateEnd}&provId={provId}&year=2014",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasures.cs",
+    "formName": "FormEhrQualityMeasures",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/quality-measures?startDate={dateStart}&endDate={dateEnd}&providerId={provId}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQualityMeasures2014.cs",
+    "formName": "FormEhrQualityMeasures2014",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/quality-measures?startDate={dateStart}&endDate={dateEnd}&providerId={provId}&year=2014",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQuarterlyKeyEdit.cs",
+    "formName": "FormEhrQuarterlyKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrQuarterlyKeyEditCust.cs",
+    "formName": "FormEhrQuarterlyKeyEditCust",
+    "endpoints": [
+      {
+        "path": "/api/ehr/quarterly-keys/generate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/quarterly-keys/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrReminders.cs",
+    "formName": "FormEhrReminders",
+    "endpoints": [
+      {
+        "path": "/api/reminder-rules?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events?patientId={id}&type=ReminderSent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSettings.cs",
+    "formName": "FormEhrSettings",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/snomed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd9",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/icd10",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSetup.cs",
+    "formName": "FormEhrSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSummaryCcdEdit.cs",
+    "formName": "FormEhrSummaryCcdEdit",
+    "endpoints": [
+      {
+        "path": "/api/summary-ccds/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrSummaryOfCare.cs",
+    "formName": "FormEhrSummaryOfCare",
+    "endpoints": [
+      {
+        "path": "/api/measure-events?patientId={id}&type=SummaryOfCareProvidedToDr",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/measure-events/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/referral-attachments?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/summary-ccds?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrTimeSynch.cs",
+    "formName": "FormEhrTimeSynch",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/server-time",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrVaccinePatEdit.cs",
+    "formName": "FormEhrVaccinePatEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ehr/vaccines?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccines",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccines/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccines/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEhrVaccines.cs",
+    "formName": "FormEhrVaccines",
+    "endpoints": [
+      {
+        "path": "/api/ehr/vaccine-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccine-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccine-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/ehr/vaccine-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormElectIDEdit.cs",
+    "formName": "FormElectIDEdit",
+    "endpoints": [
+      {
+        "path": "/api/elect-ids/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/elect-ids",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/elect-ids/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/elect-ids/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormElectIDs.cs",
+    "formName": "FormElectIDs",
+    "endpoints": [
+      {
+        "path": "/api/elect-ids",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEligibilityResponseDisplay.cs",
+    "formName": "FormEligibilityResponseDisplay",
+    "endpoints": [
+      {
+        "path": "/api/eligibilities/responses/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailAddressEdit.cs",
+    "formName": "FormEmailAddressEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-addresses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailAddresses.cs",
+    "formName": "FormEmailAddresses",
+    "endpoints": [
+      {
+        "path": "/api/email-addresses",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailAutographEdit.cs",
+    "formName": "FormEmailAutographEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-autographs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-autographs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-autographs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-autographs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailCertRegister.cs",
+    "formName": "FormEmailCertRegister",
+    "endpoints": [
+      {
+        "path": "/api/email-certificates/register",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailDigitalSignature.cs",
+    "formName": "FormEmailDigitalSignature",
+    "endpoints": [
+      {
+        "path": "/api/email-certificates/sign",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailEdit.cs",
+    "formName": "FormEmailEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailHostingAddressVerification.cs",
+    "formName": "FormEmailHostingAddressVerification",
+    "endpoints": [
+      {
+        "path": "/api/email-hosting/addresses/verify",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailHostingSignatures.cs",
+    "formName": "FormEmailHostingSignatures",
+    "endpoints": [
+      {
+        "path": "/api/email-hosting/signatures",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-hosting/signatures",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailInbox.cs",
+    "formName": "FormEmailInbox",
+    "endpoints": [
+      {
+        "path": "/api/email-messages/inbox",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailMessageEdit.cs",
+    "formName": "FormEmailMessageEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmailTemplateEdit.cs",
+    "formName": "FormEmailTemplateEdit",
+    "endpoints": [
+      {
+        "path": "/api/email-templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-templates",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/email-templates/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/email-templates/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmployeeEdit.cs",
+    "formName": "FormEmployeeEdit",
+    "endpoints": [
+      {
+        "path": "/api/employees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employees",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/employees/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/employees/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmployeeSelect.cs",
+    "formName": "FormEmployeeSelect",
+    "endpoints": [
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEmployers.cs",
+    "formName": "FormEmployers",
+    "endpoints": [
+      {
+        "path": "/api/employers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/employers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/employers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEncounterEdit.cs",
+    "formName": "FormEncounterEdit",
+    "endpoints": [
+      {
+        "path": "/api/encounters/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/encounters",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/encounters/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/encounters/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEncounterTool.cs",
+    "formName": "FormEncounterTool",
+    "endpoints": [
+      {
+        "path": "/api/encounters?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEncounters.cs",
+    "formName": "FormEncounters",
+    "endpoints": [
+      {
+        "path": "/api/encounters?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEquipment.cs",
+    "formName": "FormEquipment",
+    "endpoints": [
+      {
+        "path": "/api/equipment",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/equipment",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEquipmentEdit.cs",
+    "formName": "FormEquipmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/equipment/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/equipment/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/equipment/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormErx.cs",
+    "formName": "FormErx",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/erx/session",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormErxAccess.cs",
+    "formName": "FormErxAccess",
+    "endpoints": [
+      {
+        "path": "/api/erx/access",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormErxSetup.cs",
+    "formName": "FormErxSetup",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEservicesPaymentPortal.cs",
+    "formName": "FormEservicesPaymentPortal",
+    "endpoints": [
+      {
+        "path": "/api/eservices/payment-portal",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans270EBraw.cs",
+    "formName": "FormEtrans270EBraw",
+    "endpoints": [
+      {
+        "path": "/api/etrans/270/{id}/raw",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans270Edit.cs",
+    "formName": "FormEtrans270Edit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/270/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/270/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/270/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans277Edit.cs",
+    "formName": "FormEtrans277Edit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/277/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans834Import.cs",
+    "formName": "FormEtrans834Import",
+    "endpoints": [
+      {
+        "path": "/api/etrans/834/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans834Preview.cs",
+    "formName": "FormEtrans834Preview",
+    "endpoints": [
+      {
+        "path": "/api/etrans/834/preview",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ClaimEdit.cs",
+    "formName": "FormEtrans835ClaimEdit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/claims/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/835/claims/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/835/claims/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ClaimPay.cs",
+    "formName": "FormEtrans835ClaimPay",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/claims/{id}/pay",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ClaimSelect.cs",
+    "formName": "FormEtrans835ClaimSelect",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/claims",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835Edit.cs",
+    "formName": "FormEtrans835Edit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835PickEob.cs",
+    "formName": "FormEtrans835PickEob",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/eobs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835PickEra.cs",
+    "formName": "FormEtrans835PickEra",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/eras",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835ProcEdit.cs",
+    "formName": "FormEtrans835ProcEdit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/835/procedures/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtrans835s.cs",
+    "formName": "FormEtrans835s",
+    "endpoints": [
+      {
+        "path": "/api/etrans/835",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEtransEdit.cs",
+    "formName": "FormEtransEdit",
+    "endpoints": [
+      {
+        "path": "/api/etrans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/etrans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationCriterionDefEdit.cs",
+    "formName": "FormEvaluationCriterionDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/evaluation-criterion-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-criterion-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-criterion-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-criterion-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationDefEdit.cs",
+    "formName": "FormEvaluationDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/evaluation-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluation-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationDefs.cs",
+    "formName": "FormEvaluationDefs",
+    "endpoints": [
+      {
+        "path": "/api/evaluation-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationEdit.cs",
+    "formName": "FormEvaluationEdit",
+    "endpoints": [
+      {
+        "path": "/api/evaluations/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/evaluations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluationReport.cs",
+    "formName": "FormEvaluationReport",
+    "endpoints": [
+      {
+        "path": "/api/evaluations/report",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormEvaluations.cs",
+    "formName": "FormEvaluations",
+    "endpoints": [
+      {
+        "path": "/api/evaluations",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormExamSheets.cs",
+    "formName": "FormExamSheets",
+    "endpoints": [
+      {
+        "path": "/api/exam-sheets",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/exam-sheets",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/exam-sheets/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/exam-sheets/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFHIRAPIKeyEdit.cs",
+    "formName": "FormFHIRAPIKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/fhir/api-keys",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/api-keys",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/api-keys/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFHIRAssignKey.cs",
+    "formName": "FormFHIRAssignKey",
+    "endpoints": [
+      {
+        "path": "/api/fhir/api-keys/assign",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/api-keys/assign",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFHIRSetup.cs",
+    "formName": "FormFHIRSetup",
+    "endpoints": [
+      {
+        "path": "/api/fhir/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fhir/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFamilyBalancer.cs",
+    "formName": "FormFamilyBalancer",
+    "endpoints": [
+      {
+        "path": "/api/families/{id}/balance",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFamilyHealthEdit.cs",
+    "formName": "FormFamilyHealthEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/family-health/{patientId}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFamilyMemberSelect.cs",
+    "formName": "FormFamilyMemberSelect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeatureRequest.cs",
+    "formName": "FormFeatureRequest",
+    "endpoints": [
+      {
+        "path": "/api/feature-requests",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/feature-requests",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeEdit.cs",
+    "formName": "FormFeeEdit",
+    "endpoints": [
+      {
+        "path": "/api/fees/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fees/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/fees/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedGroupEdit.cs",
+    "formName": "FormFeeSchedGroupEdit",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedule-groups/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedule-groups/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedule-groups/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedGroups.cs",
+    "formName": "FormFeeSchedGroups",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedule-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedule-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedPickAuthOntario.cs",
+    "formName": "FormFeeSchedPickAuthOntario",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/ontario",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedPickRemote.cs",
+    "formName": "FormFeeSchedPickRemote",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/remote",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeSchedTools.cs",
+    "formName": "FormFeeSchedTools",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/tools",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeeScheds.cs",
+    "formName": "FormFeeScheds",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/fee-schedules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFeesForIns.cs",
+    "formName": "FormFeesForIns",
+    "endpoints": [
+      {
+        "path": "/api/fee-schedules/insurance",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFieldDefLink.cs",
+    "formName": "FormFieldDefLink",
+    "endpoints": [
+      {
+        "path": "/api/field-def-links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/field-def-links",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/field-def-links/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFilePicker.cs",
+    "formName": "FormFilePicker",
+    "endpoints": [
+      {
+        "path": "/api/files",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFinanceCharges.cs",
+    "formName": "FormFinanceCharges",
+    "endpoints": [
+      {
+        "path": "/api/finance-charges",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/finance-charges",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormFormPatEdit.cs",
+    "formName": "FormFormPatEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/forms",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/forms/{formId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/forms/{formId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGlobalSecurity.cs",
+    "formName": "FormGlobalSecurity",
+    "endpoints": [
+      {
+        "path": "/api/security/global",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/security/global",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGradingScaleEdit.cs",
+    "formName": "FormGradingScaleEdit",
+    "endpoints": [
+      {
+        "path": "/api/grading-scales/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/grading-scales/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/grading-scales/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGradingScales.cs",
+    "formName": "FormGradingScales",
+    "endpoints": [
+      {
+        "path": "/api/grading-scales",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/grading-scales",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGraphEmployeeTime.cs",
+    "formName": "FormGraphEmployeeTime",
+    "endpoints": [
+      {
+        "path": "/api/employee-time/graph",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGraphEmployeeView.cs",
+    "formName": "FormGraphEmployeeView",
+    "endpoints": [
+      {
+        "path": "/api/employee-time/view",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGraphics.cs",
+    "formName": "FormGraphics",
+    "endpoints": [
+      {
+        "path": "/api/graphics/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/graphics/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGridSelection.cs",
+    "formName": "FormGridSelection",
+    "endpoints": [
+      {
+        "path": "/api/grid-selection",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGroupPermEdit.cs",
+    "formName": "FormGroupPermEdit",
+    "endpoints": [
+      {
+        "path": "/api/permissions/groups/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/permissions/groups/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormGuardianEdit.cs",
+    "formName": "FormGuardianEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/guardians/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/guardians/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefEdit.cs",
+    "formName": "FormHL7DefEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definitions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definitions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definitions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefFieldEdit.cs",
+    "formName": "FormHL7DefFieldEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definition-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-fields/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefMessageEdit.cs",
+    "formName": "FormHL7DefMessageEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definition-messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7DefSegmentEdit.cs",
+    "formName": "FormHL7DefSegmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definition-segments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-segments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definition-segments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7Defs.cs",
+    "formName": "FormHL7Defs",
+    "endpoints": [
+      {
+        "path": "/api/hl7/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/definitions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7MsgEdit.cs",
+    "formName": "FormHL7MsgEdit",
+    "endpoints": [
+      {
+        "path": "/api/hl7/messages/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/messages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/hl7/messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHL7Msgs.cs",
+    "formName": "FormHL7Msgs",
+    "endpoints": [
+      {
+        "path": "/api/hl7/messages",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHcpcs.cs",
+    "formName": "FormHcpcs",
+    "endpoints": [
+      {
+        "path": "/api/hcpcs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormHieSetup.cs",
+    "formName": "FormHieSetup",
+    "endpoints": [
+      {
+        "path": "/api/hie/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/hie/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormIcd10s.cs",
+    "formName": "FormIcd10s",
+    "endpoints": [
+      {
+        "path": "/api/icd10",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormIcd9s.cs",
+    "formName": "FormIcd9s",
+    "endpoints": [
+      {
+        "path": "/api/icd9",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageCatMerge.cs",
+    "formName": "FormImageCatMerge",
+    "endpoints": [
+      {
+        "path": "/api/image-categories/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageDrawColor.cs",
+    "formName": "FormImageDrawColor",
+    "endpoints": [
+      {
+        "path": "/api/images/draw-color",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageFloat.cs",
+    "formName": "FormImageFloat",
+    "endpoints": [
+      {
+        "path": "/api/images/float",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagePicker.cs",
+    "formName": "FormImagePicker",
+    "endpoints": [
+      {
+        "path": "/api/images",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagePickerDXC.cs",
+    "formName": "FormImagePickerDXC",
+    "endpoints": [
+      {
+        "path": "/api/images/dxc",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagePickerPatient.cs",
+    "formName": "FormImagePickerPatient",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageSelect.cs",
+    "formName": "FormImageSelect",
+    "endpoints": [
+      {
+        "path": "/api/images/select",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImageSelectClaimAttach.cs",
+    "formName": "FormImageSelectClaimAttach",
+    "endpoints": [
+      {
+        "path": "/api/claims/{id}/attachments",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImages.cs",
+    "formName": "FormImages",
+    "endpoints": [
+      {
+        "path": "/api/images",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/images",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/images/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagingDeviceEdit.cs",
+    "formName": "FormImagingDeviceEdit",
+    "endpoints": [
+      {
+        "path": "/api/imaging-devices/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging-devices/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging-devices/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagingDevices.cs",
+    "formName": "FormImagingDevices",
+    "endpoints": [
+      {
+        "path": "/api/imaging-devices",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging-devices",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormImagingSetup.cs",
+    "formName": "FormImagingSetup",
+    "endpoints": [
+      {
+        "path": "/api/imaging/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/imaging/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormIncomeTransferManage.cs",
+    "formName": "FormIncomeTransferManage",
+    "endpoints": [
+      {
+        "path": "/api/income-transfers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/income-transfers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/income-transfers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInfobutton.cs",
+    "formName": "FormInfobutton",
+    "endpoints": [
+      {
+        "path": "/api/infobutton",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInnoDb.cs",
+    "formName": "FormInnoDb",
+    "endpoints": [
+      {
+        "path": "/api/database/innodb",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsAdj.cs",
+    "formName": "FormInsAdj",
+    "endpoints": [
+      {
+        "path": "/api/insurance/adjustments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/adjustments",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBenefitNotes.cs",
+    "formName": "FormInsBenefitNotes",
+    "endpoints": [
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBenefits.cs",
+    "formName": "FormInsBenefits",
+    "endpoints": [
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/ins-benefit-notes/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBlueBookRuleEdit.cs",
+    "formName": "FormInsBlueBookRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/ins-bluebook-rules/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsBlueBookRules.cs",
+    "formName": "FormInsBlueBookRules",
+    "endpoints": [
+      {
+        "path": "/api/ins-bluebook-rules",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsCatEdit.cs",
+    "formName": "FormInsCatEdit",
+    "endpoints": [
+      {
+        "path": "/api/insurance/categories/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/categories/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/categories/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsCatsSetup.cs",
+    "formName": "FormInsCatsSetup",
+    "endpoints": [
+      {
+        "path": "/api/insurance/categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/categories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsEditLogs.cs",
+    "formName": "FormInsEditLogs",
+    "endpoints": [
+      {
+        "path": "/api/insurance/edit-logs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsEditPatLog.cs",
+    "formName": "FormInsEditPatLog",
+    "endpoints": [
+      {
+        "path": "/api/insurance/patient-logs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsFilingCodeEdit.cs",
+    "formName": "FormInsFilingCodeEdit",
+    "endpoints": [
+      {
+        "path": "/api/insurance/filing-codes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/filing-codes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/filing-codes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsFilingCodes.cs",
+    "formName": "FormInsFilingCodes",
+    "endpoints": [
+      {
+        "path": "/api/insurance/filing-codes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/filing-codes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsHistSetup.cs",
+    "formName": "FormInsHistSetup",
+    "endpoints": [
+      {
+        "path": "/api/insurance/history-settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/history-settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPayFix.cs",
+    "formName": "FormInsPayFix",
+    "endpoints": [
+      {
+        "path": "/api/insurance/payments/fix",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlan.cs",
+    "formName": "FormInsPlan",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlanConvert_7_5_17.cs",
+    "formName": "FormInsPlanConvert_7_5_17",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/convert",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlanSelectFam.cs",
+    "formName": "FormInsPlanSelectFam",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/family",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlanSubstitution.cs",
+    "formName": "FormInsPlanSubstitution",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/substitution",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlans.cs",
+    "formName": "FormInsPlans",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlansMerge.cs",
+    "formName": "FormInsPlansMerge",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsPlansOverrides.cs",
+    "formName": "FormInsPlansOverrides",
+    "endpoints": [
+      {
+        "path": "/api/insurance/plans/{id}/overrides",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/plans/{id}/overrides",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsRemain.cs",
+    "formName": "FormInsRemain",
+    "endpoints": [
+      {
+        "path": "/api/insurance/remaining",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsSpanEdit.cs",
+    "formName": "FormInsSpanEdit",
+    "endpoints": [
+      {
+        "path": "/api/insurance/spans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/spans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/spans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsVerificationList.cs",
+    "formName": "FormInsVerificationList",
+    "endpoints": [
+      {
+        "path": "/api/insurance/verification",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInsVerificationSetup.cs",
+    "formName": "FormInsVerificationSetup",
+    "endpoints": [
+      {
+        "path": "/api/insurance/verification/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/insurance/verification/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInstallmentPlanEdit.cs",
+    "formName": "FormInstallmentPlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/installment-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/installment-plans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/installment-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInterventionEdit.cs",
+    "formName": "FormInterventionEdit",
+    "endpoints": [
+      {
+        "path": "/api/interventions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/interventions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/interventions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInterventions.cs",
+    "formName": "FormInterventions",
+    "endpoints": [
+      {
+        "path": "/api/interventions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/interventions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormInvoiceItemSelect.cs",
+    "formName": "FormInvoiceItemSelect",
+    "endpoints": [
+      {
+        "path": "/api/invoices/items",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormJournal.cs",
+    "formName": "FormJournal",
+    "endpoints": [
+      {
+        "path": "/api/journal-entries",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormJournalEntryEdit.cs",
+    "formName": "FormJournalEntryEdit",
+    "endpoints": [
+      {
+        "path": "/api/journal-entries/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/journal-entries/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/journal-entries/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabCaseEdit.cs",
+    "formName": "FormLabCaseEdit",
+    "endpoints": [
+      {
+        "path": "/api/lab-cases/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-cases/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/laboratories",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabCaseSelect.cs",
+    "formName": "FormLabCaseSelect",
+    "endpoints": [
+      {
+        "path": "/api/lab-cases",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabCases.cs",
+    "formName": "FormLabCases",
+    "endpoints": [
+      {
+        "path": "/api/lab-cases",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLabTurnaroundEdit.cs",
+    "formName": "FormLabTurnaroundEdit",
+    "endpoints": [
+      {
+        "path": "/api/lab-turnarounds/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/lab-turnarounds/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLaboratories.cs",
+    "formName": "FormLaboratories",
+    "endpoints": [
+      {
+        "path": "/api/laboratories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/laboratories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLaboratoryEdit.cs",
+    "formName": "FormLaboratoryEdit",
+    "endpoints": [
+      {
+        "path": "/api/laboratories/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/laboratories/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLanguageAndRegion.cs",
+    "formName": "FormLanguageAndRegion",
+    "endpoints": [
+      {
+        "path": "/api/preferences/language",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/language",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLanguageDefs.cs",
+    "formName": "FormLanguageDefs",
+    "endpoints": [
+      {
+        "path": "/api/languages/definitions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/languages/definitions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLanguagesUsed.cs",
+    "formName": "FormLanguagesUsed",
+    "endpoints": [
+      {
+        "path": "/api/languages",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLateCharges.cs",
+    "formName": "FormLateCharges",
+    "endpoints": [
+      {
+        "path": "/api/late-charges",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetterEdit.cs",
+    "formName": "FormLetterEdit",
+    "endpoints": [
+      {
+        "path": "/api/letters/templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/letters/templates/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetterMergeEdit.cs",
+    "formName": "FormLetterMergeEdit",
+    "endpoints": [
+      {
+        "path": "/api/letters/merges/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/letters/merges/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetterMerges.cs",
+    "formName": "FormLetterMerges",
+    "endpoints": [
+      {
+        "path": "/api/letters/merges",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLetters.cs",
+    "formName": "FormLetters",
+    "endpoints": [
+      {
+        "path": "/api/letters",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLicense.cs",
+    "formName": "FormLicense",
+    "endpoints": [
+      {
+        "path": "/api/license",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/license",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLimitedStatementSelect.cs",
+    "formName": "FormLimitedStatementSelect",
+    "endpoints": [
+      {
+        "path": "/api/statements",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLogOn.cs",
+    "formName": "FormLogOn",
+    "endpoints": [
+      {
+        "path": "/api/auth/login",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLoginFailed.cs",
+    "formName": "FormLoginFailed",
+    "endpoints": [
+      {
+        "path": "/api/security-logs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormLoincs.cs",
+    "formName": "FormLoincs",
+    "endpoints": [
+      {
+        "path": "/api/loincs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMapAreaEdit.cs",
+    "formName": "FormMapAreaEdit",
+    "endpoints": [
+      {
+        "path": "/api/map-areas/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/map-areas/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMarkupTableEdit.cs",
+    "formName": "FormMarkupTableEdit",
+    "endpoints": [
+      {
+        "path": "/api/markup-tables/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/markup-tables/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailAnalytics.cs",
+    "formName": "FormMassEmailAnalytics",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/analytics",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailBirthdays.cs",
+    "formName": "FormMassEmailBirthdays",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/birthdays",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailExamples.cs",
+    "formName": "FormMassEmailExamples",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/examples",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailSend.cs",
+    "formName": "FormMassEmailSend",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/send",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailSendResults.cs",
+    "formName": "FormMassEmailSendResults",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailSetup.cs",
+    "formName": "FormMassEmailSetup",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mass-email/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailTemplate.cs",
+    "formName": "FormMassEmailTemplate",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mass-email/templates/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMassEmailTemplates.cs",
+    "formName": "FormMassEmailTemplates",
+    "endpoints": [
+      {
+        "path": "/api/mass-email/templates",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mass-email/templates",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabEdit.cs",
+    "formName": "FormMedLabEdit",
+    "endpoints": [
+      {
+        "path": "/api/med-labs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/med-labs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabHL7MsgText.cs",
+    "formName": "FormMedLabHL7MsgText",
+    "endpoints": [
+      {
+        "path": "/api/med-labs/{id}/hl7",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabPatSelect.cs",
+    "formName": "FormMedLabPatSelect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabResultHist.cs",
+    "formName": "FormMedLabResultHist",
+    "endpoints": [
+      {
+        "path": "/api/med-labs/{id}/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedLabs.cs",
+    "formName": "FormMedLabs",
+    "endpoints": [
+      {
+        "path": "/api/med-labs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedPat.cs",
+    "formName": "FormMedPat",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/medications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedical.cs",
+    "formName": "FormMedical",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/medical",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}/medical",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedicationEdit.cs",
+    "formName": "FormMedicationEdit",
+    "endpoints": [
+      {
+        "path": "/api/medications/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/medications/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedicationMerge.cs",
+    "formName": "FormMedicationMerge",
+    "endpoints": [
+      {
+        "path": "/api/medications/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedicationReconcile.cs",
+    "formName": "FormMedicationReconcile",
+    "endpoints": [
+      {
+        "path": "/api/medications/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMedications.cs",
+    "formName": "FormMedications",
+    "endpoints": [
+      {
+        "path": "/api/medications",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessageReplacementTextEdit.cs",
+    "formName": "FormMessageReplacementTextEdit",
+    "endpoints": [
+      {
+        "path": "/api/messages/replacements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messages/replacements/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessageToPayEdit.cs",
+    "formName": "FormMessageToPayEdit",
+    "endpoints": [
+      {
+        "path": "/api/messages/pay/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messages/pay/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessagingButSetup.cs",
+    "formName": "FormMessagingButSetup",
+    "endpoints": [
+      {
+        "path": "/api/messaging/buttons",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messaging/buttons",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMessagingSetup.cs",
+    "formName": "FormMessagingSetup",
+    "endpoints": [
+      {
+        "path": "/api/messaging/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/messaging/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMobileBrandingProfileEdit.cs",
+    "formName": "FormMobileBrandingProfileEdit",
+    "endpoints": [
+      {
+        "path": "/api/mobile/branding/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/mobile/branding/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMobileCode.cs",
+    "formName": "FormMobileCode",
+    "endpoints": [
+      {
+        "path": "/api/mobile/code",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountDefEdit.cs",
+    "formName": "FormMountDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/radiology/mount-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountDefGenerate.cs",
+    "formName": "FormMountDefGenerate",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-defs/generate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountDefs.cs",
+    "formName": "FormMountDefs",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountItemDefEdit.cs",
+    "formName": "FormMountItemDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/radiology/mount-items/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/radiology/mount-items/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMountainside.cs",
+    "formName": "FormMountainside",
+    "endpoints": [
+      {
+        "path": "/api/mountainside",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormMultiVisitGroup.cs",
+    "formName": "FormMultiVisitGroup",
+    "endpoints": [
+      {
+        "path": "/api/multi-visit-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/multi-visit-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormNewCropBilling.cs",
+    "formName": "FormNewCropBilling",
+    "endpoints": [
+      {
+        "path": "/api/newcrop/billing",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/newcrop/billing",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormNotePick.cs",
+    "formName": "FormNotePick",
+    "endpoints": [
+      {
+        "path": "/api/notes/templates",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormODTouchSecurityEdit.cs",
+    "formName": "FormODTouchSecurityEdit",
+    "endpoints": [
+      {
+        "path": "/api/odtouch/security",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/odtouch/security",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOIDRegistryInternal.cs",
+    "formName": "FormOIDRegistryInternal",
+    "endpoints": [
+      {
+        "path": "/api/oid-registry",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOnlinePayments.cs",
+    "formName": "FormOnlinePayments",
+    "endpoints": [
+      {
+        "path": "/api/online-payments",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOperatories.cs",
+    "formName": "FormOperatories",
+    "endpoints": [
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOperatoryEdit.cs",
+    "formName": "FormOperatoryEdit",
+    "endpoints": [
+      {
+        "path": "/api/operatories/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/operatories/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOperatoryPick.cs",
+    "formName": "FormOperatoryPick",
+    "endpoints": [
+      {
+        "path": "/api/operatories",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoAutoClaims.cs",
+    "formName": "FormOrthoAutoClaims",
+    "endpoints": [
+      {
+        "path": "/api/ortho/auto-claims",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoCase.cs",
+    "formName": "FormOrthoCase",
+    "endpoints": [
+      {
+        "path": "/api/ortho/cases/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/cases/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoChart.cs",
+    "formName": "FormOrthoChart",
+    "endpoints": [
+      {
+        "path": "/api/ortho/charts/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/charts/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoChartSetup.cs",
+    "formName": "FormOrthoChartSetup",
+    "endpoints": [
+      {
+        "path": "/api/ortho/charts/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/charts/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareAdd.cs",
+    "formName": "FormOrthoHardwareAdd",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareEdit.cs",
+    "formName": "FormOrthoHardwareEdit",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/hardware/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareSpecEdit.cs",
+    "formName": "FormOrthoHardwareSpecEdit",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware/specs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/hardware/specs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoHardwareSpecs.cs",
+    "formName": "FormOrthoHardwareSpecs",
+    "endpoints": [
+      {
+        "path": "/api/ortho/hardware/specs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoPat.cs",
+    "formName": "FormOrthoPat",
+    "endpoints": [
+      {
+        "path": "/api/ortho/patients/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoRxEdit.cs",
+    "formName": "FormOrthoRxEdit",
+    "endpoints": [
+      {
+        "path": "/api/ortho/rx/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ortho/rx/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoRxSelect.cs",
+    "formName": "FormOrthoRxSelect",
+    "endpoints": [
+      {
+        "path": "/api/ortho/rx",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormOrthoRxSetup.cs",
+    "formName": "FormOrthoRxSetup",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldCheckEdit.cs",
+    "formName": "FormPatFieldCheckEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldCurrencyEdit.cs",
+    "formName": "FormPatFieldCurrencyEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldDateEdit.cs",
+    "formName": "FormPatFieldDateEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldDefEdit.cs",
+    "formName": "FormPatFieldDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-field-defs/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-field-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldDefs.cs",
+    "formName": "FormPatFieldDefs",
+    "endpoints": [
+      {
+        "path": "/api/patient-field-defs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldEdit.cs",
+    "formName": "FormPatFieldEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatFieldPickEdit.cs",
+    "formName": "FormPatFieldPickEdit",
+    "endpoints": [
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatList2014.cs",
+    "formName": "FormPatList2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListEHR2014.cs",
+    "formName": "FormPatListEHR2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/ehr",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListElementEdit2014.cs",
+    "formName": "FormPatListElementEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/elements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-lists/elements/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListElementEditEHR2014.cs",
+    "formName": "FormPatListElementEditEHR2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/ehr/elements/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-lists/ehr/elements/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListResults2014.cs",
+    "formName": "FormPatListResults2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatListResultsEHR2014.cs",
+    "formName": "FormPatListResultsEHR2014",
+    "endpoints": [
+      {
+        "path": "/api/patient-lists/ehr/results",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPath.cs",
+    "formName": "FormPath",
+    "endpoints": [
+      {
+        "path": "/api/preferences/path",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/path",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientEdit.cs",
+    "formName": "FormPatientEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/email",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientForms.cs",
+    "formName": "FormPatientForms",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/forms",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/forms",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientListDiscount.cs",
+    "formName": "FormPatientListDiscount",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientMerge.cs",
+    "formName": "FormPatientMerge",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientPickWebForm.cs",
+    "formName": "FormPatientPickWebForm",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientPortal.cs",
+    "formName": "FormPatientPortal",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPatientStatusTool.cs",
+    "formName": "FormPatientStatusTool",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnect.cs",
+    "formName": "FormPayConnect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payconnect/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnect2.cs",
+    "formName": "FormPayConnect2",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/payconnect2/transactions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnect2iFrame.cs",
+    "formName": "FormPayConnect2iFrame",
+    "endpoints": [
+      {
+        "path": "/api/payconnect2/transactions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayConnectSetup.cs",
+    "formName": "FormPayConnectSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/payconnect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/payconnect/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPeriodEdit.cs",
+    "formName": "FormPayPeriodEdit",
+    "endpoints": [
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPeriodManager.cs",
+    "formName": "FormPayPeriodManager",
+    "endpoints": [
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlan.cs",
+    "formName": "FormPayPlan",
+    "endpoints": [
+      {
+        "path": "/api/payplans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplans/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payplans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges?payPlanId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanChargeEdit.cs",
+    "formName": "FormPayPlanChargeEdit",
+    "endpoints": [
+      {
+        "path": "/api/payplan-charges/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-charges/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanChargeSelection.cs",
+    "formName": "FormPayPlanChargeSelection",
+    "endpoints": [
+      {
+        "path": "/api/payplan-charges",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures?patientId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanCredits.cs",
+    "formName": "FormPayPlanCredits",
+    "endpoints": [
+      {
+        "path": "/api/payplan-credits?payPlanId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-credits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-credits/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanDynamic.cs",
+    "formName": "FormPayPlanDynamic",
+    "endpoints": [
+      {
+        "path": "/api/payplans/{id}/dynamic",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplans/{id}/dynamic",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanRecalculate.cs",
+    "formName": "FormPayPlanRecalculate",
+    "endpoints": [
+      {
+        "path": "/api/payplans/{id}/recalculate",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanSelect.cs",
+    "formName": "FormPayPlanSelect",
+    "endpoints": [
+      {
+        "path": "/api/payplans?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanTemplateEdit.cs",
+    "formName": "FormPayPlanTemplateEdit",
+    "endpoints": [
+      {
+        "path": "/api/payplan-templates/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-templates/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-templates/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayPlanTemplates.cs",
+    "formName": "FormPayPlanTemplates",
+    "endpoints": [
+      {
+        "path": "/api/payplan-templates",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payplan-templates",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaySimple.cs",
+    "formName": "FormPaySimple",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/paysimple",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/paysimple/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/paysimple/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaySimpleSetup.cs",
+    "formName": "FormPaySimpleSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/paysimple",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/paysimple/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/paysimple/properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaySplitEdit.cs",
+    "formName": "FormPaySplitEdit",
+    "endpoints": [
+      {
+        "path": "/api/paysplits/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/adjustments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayTerminalEdit.cs",
+    "formName": "FormPayTerminalEdit",
+    "endpoints": [
+      {
+        "path": "/api/payterminals/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payterminals/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayment.cs",
+    "formName": "FormPayment",
+    "endpoints": [
+      {
+        "path": "/api/payments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits?paymentId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/paysplits",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPaymentPlanOptions.cs",
+    "formName": "FormPaymentPlanOptions",
+    "endpoints": [
+      {
+        "path": "/api/preferences/payment-plan-options",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/payment-plan-options",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayorTypeEdit.cs",
+    "formName": "FormPayorTypeEdit",
+    "endpoints": [
+      {
+        "path": "/api/payor-types/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payor-types/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payor-types/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPayorTypes.cs",
+    "formName": "FormPayorTypes",
+    "endpoints": [
+      {
+        "path": "/api/payor-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payor-types",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerio.cs",
+    "formName": "FormPerio",
+    "endpoints": [
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioEdit.cs",
+    "formName": "FormPerioEdit",
+    "endpoints": [
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/perio-exams/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioGraphical.cs",
+    "formName": "FormPerioGraphical",
+    "endpoints": [
+      {
+        "path": "/api/perio-exams/{id}/graph",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioGraphicalSetup.cs",
+    "formName": "FormPerioGraphicalSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences/perio-graphical",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/perio-graphical",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioSetup.cs",
+    "formName": "FormPerioSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences/perio",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/perio",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPerioVoice.cs",
+    "formName": "FormPerioVoice",
+    "endpoints": [
+      {
+        "path": "/api/preferences/perio-voice",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/perio-voice",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPharmacies.cs",
+    "formName": "FormPharmacies",
+    "endpoints": [
+      {
+        "path": "/api/pharmacies",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPharmacyEdit.cs",
+    "formName": "FormPharmacyEdit",
+    "endpoints": [
+      {
+        "path": "/api/pharmacies/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/pharmacies",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPhoneNumbersManage.cs",
+    "formName": "FormPhoneNumbersManage",
+    "endpoints": [
+      {
+        "path": "/api/phone-numbers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/phone-numbers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPlansForFamily.cs",
+    "formName": "FormPlansForFamily",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/plans",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/ins-plans?patientId={id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPodiumSetup.cs",
+    "formName": "FormPodiumSetup",
+    "endpoints": [
+      {
+        "path": "/api/programs/podium",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/podium/properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/podium/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPopupDisplay.cs",
+    "formName": "FormPopupDisplay",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/popups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPopupFade.cs",
+    "formName": "FormPopupFade",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/popups",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPopupsForFam.cs",
+    "formName": "FormPopupsForFam",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/popups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-popups",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patient-popups/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPractice.cs",
+    "formName": "FormPractice",
+    "endpoints": [
+      {
+        "path": "/api/practice",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/practice",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPreferences.cs",
+    "formName": "FormPreferences",
+    "endpoints": [
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrepaymentEdit.cs",
+    "formName": "FormPrepaymentEdit",
+    "endpoints": [
+      {
+        "path": "/api/prepayments/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prepayments/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prepayments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrepaymentTool.cs",
+    "formName": "FormPrepaymentTool",
+    "endpoints": [
+      {
+        "path": "/api/prepayments",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prepayments/allocate",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrinterEdit.cs",
+    "formName": "FormPrinterEdit",
+    "endpoints": [
+      {
+        "path": "/api/printers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/printers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrinterSetup.cs",
+    "formName": "FormPrinterSetup",
+    "endpoints": [
+      {
+        "path": "/api/printers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/printers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/printers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormPrntScrn.cs",
+    "formName": "FormPrntScrn",
+    "endpoints": [
+      {
+        "path": "/api/screenshots",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcApptColorEdit.cs",
+    "formName": "FormProcApptColorEdit",
+    "endpoints": [
+      {
+        "path": "/api/proc-appt-colors/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-appt-colors/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcApptColors.cs",
+    "formName": "FormProcApptColors",
+    "endpoints": [
+      {
+        "path": "/api/proc-appt-colors",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-appt-colors",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-appt-colors/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcBandingSelect.cs",
+    "formName": "FormProcBandingSelect",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/banding",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcBroken.cs",
+    "formName": "FormProcBroken",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}/status",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/broken-reasons",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcButtonEdit.cs",
+    "formName": "FormProcButtonEdit",
+    "endpoints": [
+      {
+        "path": "/api/proc-buttons/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-buttons/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcButtonQuickEdit.cs",
+    "formName": "FormProcButtonQuickEdit",
+    "endpoints": [
+      {
+        "path": "/api/proc-buttons/{id}",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcButtons.cs",
+    "formName": "FormProcButtons",
+    "endpoints": [
+      {
+        "path": "/api/proc-buttons",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/proc-buttons",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeEdit.cs",
+    "formName": "FormProcCodeEdit",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeEditMore.cs",
+    "formName": "FormProcCodeEditMore",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/{id}/details",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedure-codes/{id}/details",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeNew.cs",
+    "formName": "FormProcCodeNew",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodeNoteEdit.cs",
+    "formName": "FormProcCodeNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes/{id}/note",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcCodes2.cs",
+    "formName": "FormProcCodes2",
+    "endpoints": [
+      {
+        "path": "/api/procedure-codes",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcEdit.cs",
+    "formName": "FormProcEdit",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcEditAll.cs",
+    "formName": "FormProcEditAll",
+    "endpoints": [
+      {
+        "path": "/api/procedures/batch",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcGroup.cs",
+    "formName": "FormProcGroup",
+    "endpoints": [
+      {
+        "path": "/api/procedures/group",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcLockTool.cs",
+    "formName": "FormProcLockTool",
+    "endpoints": [
+      {
+        "path": "/api/procedures/lock",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcNoteAppend.cs",
+    "formName": "FormProcNoteAppend",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}/notes",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcSelect.cs",
+    "formName": "FormProcSelect",
+    "endpoints": [
+      {
+        "path": "/api/procedures",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcTPEdit.cs",
+    "formName": "FormProcTPEdit",
+    "endpoints": [
+      {
+        "path": "/api/treatment-plans/{id}/procedures",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProcTools.cs",
+    "formName": "FormProcTools",
+    "endpoints": [
+      {
+        "path": "/api/procedures/tools",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProdSelect.cs",
+    "formName": "FormProdSelect",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinkEdit.cs",
+    "formName": "FormProgramLinkEdit",
+    "endpoints": [
+      {
+        "path": "/api/program-links/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-links/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinkHideClinics.cs",
+    "formName": "FormProgramLinkHideClinics",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinkOutputFile .cs",
+    "formName": "FormProgramLinkOutputFile ",
+    "endpoints": [
+      {
+        "path": "/api/program-links/output-file",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramLinks.cs",
+    "formName": "FormProgramLinks",
+    "endpoints": [
+      {
+        "path": "/api/program-links",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-links",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProgramProperty.cs",
+    "formName": "FormProgramProperty",
+    "endpoints": [
+      {
+        "path": "/api/program-properties",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvAdditional.cs",
+    "formName": "FormProvAdditional",
+    "endpoints": [
+      {
+        "path": "/api/providers/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/provider-identifiers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvEdit.cs",
+    "formName": "FormProvEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvStudentBulkEdit.cs",
+    "formName": "FormProvStudentBulkEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers/students/bulk",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProvStudentEdit.cs",
+    "formName": "FormProvStudentEdit",
+    "endpoints": [
+      {
+        "path": "/api/providers/students/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProviderMerge.cs",
+    "formName": "FormProviderMerge",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProviderMultiPick.cs",
+    "formName": "FormProviderMultiPick",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormProviderSetup.cs",
+    "formName": "FormProviderSetup",
+    "endpoints": [
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQBAccountSelect.cs",
+    "formName": "FormQBAccountSelect",
+    "endpoints": [
+      {
+        "path": "/api/accounting/accounts",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryEdit.cs",
+    "formName": "FormQueryEdit",
+    "endpoints": [
+      {
+        "path": "/api/queries/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryFavorites.cs",
+    "formName": "FormQueryFavorites",
+    "endpoints": [
+      {
+        "path": "/api/query-favorites",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/query-favorites",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryMonitor.cs",
+    "formName": "FormQueryMonitor",
+    "endpoints": [
+      {
+        "path": "/api/queries/running",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQueryParser.cs",
+    "formName": "FormQueryParser",
+    "endpoints": [
+      {
+        "path": "/api/queries/parse",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuestionDefEdit.cs",
+    "formName": "FormQuestionDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/question-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuestionDefs.cs",
+    "formName": "FormQuestionDefs",
+    "endpoints": [
+      {
+        "path": "/api/question-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/question-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuickBooksOnlineAuthorization.cs",
+    "formName": "FormQuickBooksOnlineAuthorization",
+    "endpoints": [
+      {
+        "path": "/api/quickbooks/online/authorize",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuickBooksOnlineSetup.cs",
+    "formName": "FormQuickBooksOnlineSetup",
+    "endpoints": [
+      {
+        "path": "/api/quickbooks/online/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormQuickBooksSetup.cs",
+    "formName": "FormQuickBooksSetup",
+    "endpoints": [
+      {
+        "path": "/api/quickbooks/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRadOrderList.cs",
+    "formName": "FormRadOrderList",
+    "endpoints": [
+      {
+        "path": "/api/radiology/orders",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReactivationEdit.cs",
+    "formName": "FormReactivationEdit",
+    "endpoints": [
+      {
+        "path": "/api/reactivations/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReactivationSetup.cs",
+    "formName": "FormReactivationSetup",
+    "endpoints": [
+      {
+        "path": "/api/reactivation-rules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/reactivation-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallEdit.cs",
+    "formName": "FormRecallEdit",
+    "endpoints": [
+      {
+        "path": "/api/recalls/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallList.cs",
+    "formName": "FormRecallList",
+    "endpoints": [
+      {
+        "path": "/api/recalls/list",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallListUndo.cs",
+    "formName": "FormRecallListUndo",
+    "endpoints": [
+      {
+        "path": "/api/recalls/undo",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallSetup.cs",
+    "formName": "FormRecallSetup",
+    "endpoints": [
+      {
+        "path": "/api/recalls/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallTypeEdit.cs",
+    "formName": "FormRecallTypeEdit",
+    "endpoints": [
+      {
+        "path": "/api/recall-types/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallTypes.cs",
+    "formName": "FormRecallTypes",
+    "endpoints": [
+      {
+        "path": "/api/recall-types",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/recall-types",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecallsPat.cs",
+    "formName": "FormRecallsPat",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/recalls",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileAllergy.cs",
+    "formName": "FormReconcileAllergy",
+    "endpoints": [
+      {
+        "path": "/api/allergies/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileEdit.cs",
+    "formName": "FormReconcileEdit",
+    "endpoints": [
+      {
+        "path": "/api/reconciles/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileMedication.cs",
+    "formName": "FormReconcileMedication",
+    "endpoints": [
+      {
+        "path": "/api/medications/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconcileProblem.cs",
+    "formName": "FormReconcileProblem",
+    "endpoints": [
+      {
+        "path": "/api/problems/reconcile",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReconciles.cs",
+    "formName": "FormReconciles",
+    "endpoints": [
+      {
+        "path": "/api/reconciles",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecordAudio.cs",
+    "formName": "FormRecordAudio",
+    "endpoints": [
+      {
+        "path": "/api/audio-recordings",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRecurringChargesHistory.cs",
+    "formName": "FormRecurringChargesHistory",
+    "endpoints": [
+      {
+        "path": "/api/recurring-charges/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRedundantIndexes.cs",
+    "formName": "FormRedundantIndexes",
+    "endpoints": [
+      {
+        "path": "/api/database/indexes/redundant",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferenceEdit.cs",
+    "formName": "FormReferenceEdit",
+    "endpoints": [
+      {
+        "path": "/api/references/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferenceEntryEdit.cs",
+    "formName": "FormReferenceEntryEdit",
+    "endpoints": [
+      {
+        "path": "/api/reference-entries/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferenceSelect.cs",
+    "formName": "FormReferenceSelect",
+    "endpoints": [
+      {
+        "path": "/api/references",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferralMerge.cs",
+    "formName": "FormReferralMerge",
+    "endpoints": [
+      {
+        "path": "/api/referrals/merge",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReferralProcTrack.cs",
+    "formName": "FormReferralProcTrack",
+    "endpoints": [
+      {
+        "path": "/api/referral-procedures",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRegistrationKey.cs",
+    "formName": "FormRegistrationKey",
+    "endpoints": [
+      {
+        "path": "/api/registration-keys",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRegistrationKeyEdit.cs",
+    "formName": "FormRegistrationKeyEdit",
+    "endpoints": [
+      {
+        "path": "/api/registration-keys/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReminderRuleEdit.cs",
+    "formName": "FormReminderRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/reminder-rules/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReminderRules.cs",
+    "formName": "FormReminderRules",
+    "endpoints": [
+      {
+        "path": "/api/reminder-rules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/reminder-rules",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRepeatChargeEdit.cs",
+    "formName": "FormRepeatChargeEdit",
+    "endpoints": [
+      {
+        "path": "/api/repeat-charges/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRepeatChargeEditMulti.cs",
+    "formName": "FormRepeatChargeEditMulti",
+    "endpoints": [
+      {
+        "path": "/api/repeat-charges/bulk",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRepeatChargesUpdate.cs",
+    "formName": "FormRepeatChargesUpdate",
+    "endpoints": [
+      {
+        "path": "/api/repeat-charges/run",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReplicationEdit.cs",
+    "formName": "FormReplicationEdit",
+    "endpoints": [
+      {
+        "path": "/api/replication/servers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReplicationSetup.cs",
+    "formName": "FormReplicationSetup",
+    "endpoints": [
+      {
+        "path": "/api/replication/servers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/replication/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReportSetup.cs",
+    "formName": "FormReportSetup",
+    "endpoints": [
+      {
+        "path": "/api/reports/setup",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/reports/setup",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReportsFiltered.cs",
+    "formName": "FormReportsFiltered",
+    "endpoints": [
+      {
+        "path": "/api/reports/filter",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReportsMore.cs",
+    "formName": "FormReportsMore",
+    "endpoints": [
+      {
+        "path": "/api/reports",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqAppt.cs",
+    "formName": "FormReqAppt",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "PUT",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqFieldCondEdit.cs",
+    "formName": "FormReqFieldCondEdit",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/field-conditions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/requirements/{id}/field-conditions/{condId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqNeededEdit.cs",
+    "formName": "FormReqNeededEdit",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqNeededs.cs",
+    "formName": "FormReqNeededs",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/requirements/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqStudentEdit.cs",
+    "formName": "FormReqStudentEdit",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/students/{studentId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/requirements/{id}/students/{studentId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqStudentOne.cs",
+    "formName": "FormReqStudentOne",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/students/{studentId}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormReqStudentsMany.cs",
+    "formName": "FormReqStudentsMany",
+    "endpoints": [
+      {
+        "path": "/api/requirements/{id}/students",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRequestEdit.cs",
+    "formName": "FormRequestEdit",
+    "endpoints": [
+      {
+        "path": "/api/requests",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/requests/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRequiredFields.cs",
+    "formName": "FormRequiredFields",
+    "endpoints": [
+      {
+        "path": "/api/required-fields",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/required-fields/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormResellerEdit.cs",
+    "formName": "FormResellerEdit",
+    "endpoints": [
+      {
+        "path": "/api/resellers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/resellers/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormResellerServiceEdit.cs",
+    "formName": "FormResellerServiceEdit",
+    "endpoints": [
+      {
+        "path": "/api/resellers/{id}/services/{serviceId}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormResellers.cs",
+    "formName": "FormResellers",
+    "endpoints": [
+      {
+        "path": "/api/resellers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRpEraAutoProcessed.cs",
+    "formName": "FormRpEraAutoProcessed",
+    "endpoints": [
+      {
+        "path": "/api/eras/auto-processed",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxAlertEdit.cs",
+    "formName": "FormRxAlertEdit",
+    "endpoints": [
+      {
+        "path": "/api/rx-alerts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/rx-alerts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxCombine.cs",
+    "formName": "FormRxCombine",
+    "endpoints": [
+      {
+        "path": "/api/prescriptions/combine",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxDefEdit.cs",
+    "formName": "FormRxDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxEdit.cs",
+    "formName": "FormRxEdit",
+    "endpoints": [
+      {
+        "path": "/api/prescriptions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prescriptions/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxManage.cs",
+    "formName": "FormRxManage",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}/prescriptions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxNorms.cs",
+    "formName": "FormRxNorms",
+    "endpoints": [
+      {
+        "path": "/api/rxnorms/search",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxSelect.cs",
+    "formName": "FormRxSelect",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormRxSetup.cs",
+    "formName": "FormRxSetup",
+    "endpoints": [
+      {
+        "path": "/api/rx-defs",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/rx-defs",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScannerSetup.cs",
+    "formName": "FormScannerSetup",
+    "endpoints": [
+      {
+        "path": "/api/scanner-settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/scanner-settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchedule.cs",
+    "formName": "FormSchedule",
+    "endpoints": [
+      {
+        "path": "/api/schedules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/schedules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduleBlockEdit.cs",
+    "formName": "FormScheduleBlockEdit",
+    "endpoints": [
+      {
+        "path": "/api/schedule-blocks/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/schedule-blocks/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduleDayEdit.cs",
+    "formName": "FormScheduleDayEdit",
+    "endpoints": [
+      {
+        "path": "/api/schedule-days/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduleEdit.cs",
+    "formName": "FormScheduleEdit",
+    "endpoints": [
+      {
+        "path": "/api/schedules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/schedules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduledProcesses.cs",
+    "formName": "FormScheduledProcesses",
+    "endpoints": [
+      {
+        "path": "/api/scheduled-processes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/scheduled-processes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScheduledProcessesEdit.cs",
+    "formName": "FormScheduledProcessesEdit",
+    "endpoints": [
+      {
+        "path": "/api/scheduled-processes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/scheduled-processes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolClassEdit.cs",
+    "formName": "FormSchoolClassEdit",
+    "endpoints": [
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolClasses.cs",
+    "formName": "FormSchoolClasses",
+    "endpoints": [
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "DELETE",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolCourseEdit.cs",
+    "formName": "FormSchoolCourseEdit",
+    "endpoints": [
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/school-classes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSchoolCourses.cs",
+    "formName": "FormSchoolCourses",
+    "endpoints": [
+      {
+        "path": "/api/school-classes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/school-classes",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScreenEdit.cs",
+    "formName": "FormScreenEdit",
+    "endpoints": [
+      {
+        "path": "/api/screens/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/screens/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScreenGroupEdit.cs",
+    "formName": "FormScreenGroupEdit",
+    "endpoints": [
+      {
+        "path": "/api/screen-groups/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/screen-groups/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormScreenGroups.cs",
+    "formName": "FormScreenGroups",
+    "endpoints": [
+      {
+        "path": "/api/screen-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/screen-groups",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecureEmailSetup.cs",
+    "formName": "FormSecureEmailSetup",
+    "endpoints": [
+      {
+        "path": "/api/secure-email/settings",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/secure-email/settings",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecurity.cs",
+    "formName": "FormSecurity",
+    "endpoints": [
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/user-groups",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/permissions",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecurityCentralUserEdit.cs",
+    "formName": "FormSecurityCentralUserEdit",
+    "endpoints": [
+      {
+        "path": "/api/central-users/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/central-users/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSecurityLock.cs",
+    "formName": "FormSecurityLock",
+    "endpoints": [
+      {
+        "path": "/api/security/lock",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/security/unlock",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSetupWizard.cs",
+    "formName": "FormSetupWizard",
+    "endpoints": [
+      {
+        "path": "/api/setup-wizard",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/setup-wizard",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSetupWizardProgress.cs",
+    "formName": "FormSetupWizardProgress",
+    "endpoints": [
+      {
+        "path": "/api/setup-wizard/progress/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDef.cs",
+    "formName": "FormSheetDef",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDefDefaults.cs",
+    "formName": "FormSheetDefDefaults",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs/defaults",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/defaults",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDefEdit.cs",
+    "formName": "FormSheetDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetDefs.cs",
+    "formName": "FormSheetDefs",
+    "endpoints": [
+      {
+        "path": "/api/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheet-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetExport.cs",
+    "formName": "FormSheetExport",
+    "endpoints": [
+      {
+        "path": "/api/sheets/export",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldAdd.cs",
+    "formName": "FormSheetFieldAdd",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldChart.cs",
+    "formName": "FormSheetFieldChart",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/chart",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldCheckBox.cs",
+    "formName": "FormSheetFieldCheckBox",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/checkbox",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldComboBox.cs",
+    "formName": "FormSheetFieldComboBox",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/combobox",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldEditPatImage.cs",
+    "formName": "FormSheetFieldEditPatImage",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/pat-image/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldExam.cs",
+    "formName": "FormSheetFieldExam",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/exam",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldGrid.cs",
+    "formName": "FormSheetFieldGrid",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/grid",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldImage.cs",
+    "formName": "FormSheetFieldImage",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/image",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldInput.cs",
+    "formName": "FormSheetFieldInput",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/input",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldLine.cs",
+    "formName": "FormSheetFieldLine",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/line",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldOutput.cs",
+    "formName": "FormSheetFieldOutput",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/output",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldPatImage.cs",
+    "formName": "FormSheetFieldPatImage",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/patient-image",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldRect.cs",
+    "formName": "FormSheetFieldRect",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/rect",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldSigBox.cs",
+    "formName": "FormSheetFieldSigBox",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/signature",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldSpecial.cs",
+    "formName": "FormSheetFieldSpecial",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/special",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFieldStatic.cs",
+    "formName": "FormSheetFieldStatic",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fields/static",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetFillEdit.cs",
+    "formName": "FormSheetFillEdit",
+    "endpoints": [
+      {
+        "path": "/api/sheet-fills/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetImport.cs",
+    "formName": "FormSheetImport",
+    "endpoints": [
+      {
+        "path": "/api/sheets/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetImportEnumPicker.cs",
+    "formName": "FormSheetImportEnumPicker",
+    "endpoints": [
+      {
+        "path": "/api/sheets/import-enums",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetOutputFormat.cs",
+    "formName": "FormSheetOutputFormat",
+    "endpoints": [
+      {
+        "path": "/api/sheets/output-format",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetProcSelect.cs",
+    "formName": "FormSheetProcSelect",
+    "endpoints": [
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSheetTools.cs",
+    "formName": "FormSheetTools",
+    "endpoints": [
+      {
+        "path": "/api/sheets/tools/copy",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormShowFeatures.cs",
+    "formName": "FormShowFeatures",
+    "endpoints": [
+      {
+        "path": "/api/preferences/features",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/features",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormShutdown.cs",
+    "formName": "FormShutdown",
+    "endpoints": [
+      {
+        "path": "/api/system/shutdown",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSigButDefEdit.cs",
+    "formName": "FormSigButDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/sig-button-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-button-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-button-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSigElementDefEdit.cs",
+    "formName": "FormSigElementDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/sig-element-defs",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-element-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/sig-element-defs/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSmsTextMessaging.cs",
+    "formName": "FormSmsTextMessaging",
+    "endpoints": [
+      {
+        "path": "/api/sms/messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sms/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/sms/messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sms/credits",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSnomeds.cs",
+    "formName": "FormSnomeds",
+    "endpoints": [
+      {
+        "path": "/api/snomeds",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSpellCheck.cs",
+    "formName": "FormSpellCheck",
+    "endpoints": [
+      {
+        "path": "/api/spell-check",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSpellChecker.cs",
+    "formName": "FormSpellChecker",
+    "endpoints": [
+      {
+        "path": "/api/spell-check",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSplash.cs",
+    "formName": "FormSplash",
+    "endpoints": [
+      {
+        "path": "/api/application/version",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/server/time",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormStateAbbrEdit.cs",
+    "formName": "FormStateAbbrEdit",
+    "endpoints": [
+      {
+        "path": "/api/state-abbreviations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/state-abbreviations/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/state-abbreviations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormStateAbbrs.cs",
+    "formName": "FormStateAbbrs",
+    "endpoints": [
+      {
+        "path": "/api/state-abbreviations",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormStatementOptions.cs",
+    "formName": "FormStatementOptions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/preferences",
+        "method": "PUT",
+        "exists": true
+      },
+      {
+        "path": "/api/statements/options",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSubscriberMove .cs",
+    "formName": "FormSubscriberMove ",
+    "endpoints": [
+      {
+        "path": "/api/subscribers/{id}/move",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/insurance-plans/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSubscriberSelect.cs",
+    "formName": "FormSubscriberSelect",
+    "endpoints": [
+      {
+        "path": "/api/subscribers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSubscribersList.cs",
+    "formName": "FormSubscribersList",
+    "endpoints": [
+      {
+        "path": "/api/subscribers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplierEdit.cs",
+    "formName": "FormSupplierEdit",
+    "endpoints": [
+      {
+        "path": "/api/suppliers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/suppliers/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/suppliers/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSuppliers.cs",
+    "formName": "FormSuppliers",
+    "endpoints": [
+      {
+        "path": "/api/suppliers",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplies.cs",
+    "formName": "FormSupplies",
+    "endpoints": [
+      {
+        "path": "/api/supplies",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/supplies",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyEdit.cs",
+    "formName": "FormSupplyEdit",
+    "endpoints": [
+      {
+        "path": "/api/supplies/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/supplies/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyInventory.cs",
+    "formName": "FormSupplyInventory",
+    "endpoints": [
+      {
+        "path": "/api/supplies/inventory",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/supplies/inventory",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyOrderEdit.cs",
+    "formName": "FormSupplyOrderEdit",
+    "endpoints": [
+      {
+        "path": "/api/supply-orders",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyOrderItemEdit.cs",
+    "formName": "FormSupplyOrderItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/supply-orders/{orderId}/items",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{orderId}/items/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/supply-orders/{orderId}/items/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupplyOrders.cs",
+    "formName": "FormSupplyOrders",
+    "endpoints": [
+      {
+        "path": "/api/supply-orders",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormSupportStatus.cs",
+    "formName": "FormSupportStatus",
+    "endpoints": [
+      {
+        "path": "/api/support/status",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTPsign.cs",
+    "formName": "FormTPsign",
+    "endpoints": [
+      {
+        "path": "/api/treat-plans/{id}/signature",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskAttachmentEdit.cs",
+    "formName": "FormTaskAttachmentEdit",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/attachments",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/attachments/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskAttachments.cs",
+    "formName": "FormTaskAttachments",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/attachments",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskEdit.cs",
+    "formName": "FormTaskEdit",
+    "endpoints": [
+      {
+        "path": "/api/tasks",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskHist.cs",
+    "formName": "FormTaskHist",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{id}/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskInboxSetup.cs",
+    "formName": "FormTaskInboxSetup",
+    "endpoints": [
+      {
+        "path": "/api/task-lists",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/inbox",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskListBlock.cs",
+    "formName": "FormTaskListBlock",
+    "endpoints": [
+      {
+        "path": "/api/task-lists/{id}/block",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/{id}/block",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskListEdit.cs",
+    "formName": "FormTaskListEdit",
+    "endpoints": [
+      {
+        "path": "/api/task-lists",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskListSelect.cs",
+    "formName": "FormTaskListSelect",
+    "endpoints": [
+      {
+        "path": "/api/task-lists",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskNoteEdit.cs",
+    "formName": "FormTaskNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/notes/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/notes/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskOptions.cs",
+    "formName": "FormTaskOptions",
+    "endpoints": [
+      {
+        "path": "/api/preferences/task-options",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/task-options",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskPreferences.cs",
+    "formName": "FormTaskPreferences",
+    "endpoints": [
+      {
+        "path": "/api/preferences/task",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/task",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskSearch.cs",
+    "formName": "FormTaskSearch",
+    "endpoints": [
+      {
+        "path": "/api/tasks/search",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaskSubscribers.cs",
+    "formName": "FormTaskSubscribers",
+    "endpoints": [
+      {
+        "path": "/api/tasks/{taskId}/subscribers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/subscribers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/tasks/{taskId}/subscribers/{userId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTasks.cs",
+    "formName": "FormTasks",
+    "endpoints": [
+      {
+        "path": "/api/tasks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/task-lists",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTasksForAppt.cs",
+    "formName": "FormTasksForAppt",
+    "endpoints": [
+      {
+        "path": "/api/appointments/{id}/tasks",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}/tasks",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTaxAddress.cs",
+    "formName": "FormTaxAddress",
+    "endpoints": [
+      {
+        "path": "/api/addresses/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/addresses",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/addresses/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/addresses/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTelephone.cs",
+    "formName": "FormTelephone",
+    "endpoints": [
+      {
+        "path": "/api/patients/reformat-phone-numbers",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTerminal.cs",
+    "formName": "FormTerminal",
+    "endpoints": [
+      {
+        "path": "/api/terminalactives",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives?computerName={name}&sessionId={sessionId}&processId={processId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives?computerName={name}&sessionId={sessionId}&processId={processId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/sheets?patNum={patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/signalods",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTerminalConnection.cs",
+    "formName": "FormTerminalConnection",
+    "endpoints": [
+      {
+        "path": "/api/terminals/connect",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTerminalManager.cs",
+    "formName": "FormTerminalManager",
+    "endpoints": [
+      {
+        "path": "/api/terminalactives",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/terminalactives/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/mobileappdevices",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheets?patNum={patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sheets/checkin?aptNum={aptNum}",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments?patNum={patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?name=TerminalClosePassword",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/signalods",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTestLatency.cs",
+    "formName": "FormTestLatency",
+    "endpoints": [
+      {
+        "path": "/api/misc/version",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeAdjustEdit.cs",
+    "formName": "FormTimeAdjustEdit",
+    "endpoints": [
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=TimeCardAdjTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods?date={date}&employeeId={employeeNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCard.cs",
+    "formName": "FormTimeCard",
+    "endpoints": [
+      {
+        "path": "/api/clockevents?employeeNum={employeeNum}&start={start}&end={end}&isBreaks={isBreaks}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts?employeeNum={employeeNum}&start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?category=TimeCard",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/misc/now",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardBenefitsRp.cs",
+    "formName": "FormTimeCardBenefitsRp",
+    "endpoints": [
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clockevents?start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timeadjusts?start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/misc/now",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardManage.cs",
+    "formName": "FormTimeCardManage",
+    "endpoints": [
+      {
+        "path": "/api/clockevents/timecardmanage?start={start}&end={end}&clinicNum={clinicNum}&all={isAll}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?names=TimeCardsUseDecimalInsteadOfColon,TimeCardShowSeconds",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardRuleEdit.cs",
+    "formName": "FormTimeCardRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/employees?clinicNum={clinicNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimeCardSetup.cs",
+    "formName": "FormTimeCardSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences?names=TimeCardsUseDecimalInsteadOfColon,TimeCardsMakesAdjustmentsForOverBreaks,TimeCardShowSeconds,ADPRunIID,ADPCompanyCode",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/{name}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/payperiods/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/timecardrules",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clockevents?start={start}&end={end}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTimePick.cs",
+    "formName": "FormTimePick",
+    "endpoints": [
+      {
+        "path": "/api/time/server",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormToothChartBig.cs",
+    "formName": "FormToothChartBig",
+    "endpoints": [
+      {
+        "path": "/api/preferences?name=UseInternationalToothNumbers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ChartGraphicColors",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computerprefs?computerName={computerName}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/computerprefs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrackNext.cs",
+    "formName": "FormTrackNext",
+    "endpoints": [
+      {
+        "path": "/api/appointments/plannedtracker?order={order}&provNum={provNum}&siteNum={siteNum}&clinicNum={clinicNum}&codeStart={codeStart}&codeEnd={codeEnd}&dateFrom={dateFrom}&dateTo={dateTo}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/sites",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?names=PlannedApptDaysPast,PlannedApptDaysFuture,EasyHidePublicHealth,EnterpriseApptList",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrackNextSetup.cs",
+    "formName": "FormTrackNextSetup",
+    "endpoints": [
+      {
+        "path": "/api/preferences?name=PlannedApptDaysPast",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences?name=PlannedApptDaysFuture",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/PlannedApptDaysPast",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/preferences/PlannedApptDaysFuture",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTransactionEdit.cs",
+    "formName": "FormTransactionEdit",
+    "endpoints": [
+      {
+        "path": "/api/transactions",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/transactions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/transactions/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries?transactionId={id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/journalentries/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/accounts/{accountNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/deposits/{depositNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/payments/{payNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{patNum}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/transactioninvoices/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/securitylogs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTranslation.cs",
+    "formName": "FormTranslation",
+    "endpoints": [
+      {
+        "path": "/api/translations?classType={type}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/translations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTranslationCat.cs",
+    "formName": "FormTranslationCat",
+    "endpoints": [
+      {
+        "path": "/api/translations/categories",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/export",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTranslationEdit.cs",
+    "formName": "FormTranslationEdit",
+    "endpoints": [
+      {
+        "path": "/api/translations",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/translations/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTransworldSetup.cs",
+    "formName": "FormTransworldSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/transworld",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/transworld",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties?program=Transworld",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTreatPlanCurEdit.cs",
+    "formName": "FormTreatPlanCurEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTreatPlanDiscount.cs",
+    "formName": "FormTreatPlanDiscount",
+    "endpoints": [
+      {
+        "path": "/api/prefs/TreatPlanDiscountPercent",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTreatPlanEdit.cs",
+    "formName": "FormTreatPlanEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/treatment-plans",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/treatment-plans/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/procedures/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrojanCollect.cs",
+    "formName": "FormTrojanCollect",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/employers/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/trojan/collect",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrojanCollectSetup.cs",
+    "formName": "FormTrojanCollectSetup",
+    "endpoints": [
+      {
+        "path": "/api/definitions?category=BillingTypes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/trojan-collect",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/trojan-collect",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/program-properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTrojanHelp.cs",
+    "formName": "FormTrojanHelp",
+    "endpoints": [
+      {
+        "path": "/api/trojan/help",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTsiHistory.cs",
+    "formName": "FormTsiHistory",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/tsi-translogs",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTxtMsgEdit.cs",
+    "formName": "FormTxtMsgEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/text-messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/text-messages/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/text-messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormTxtMsgMany.cs",
+    "formName": "FormTxtMsgMany",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/text-messages/bulk",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUcums.cs",
+    "formName": "FormUcums",
+    "endpoints": [
+      {
+        "path": "/api/ucums?search={text}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUnsched.cs",
+    "formName": "FormUnsched",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appointments?status=unscheduled",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "PATCH",
+        "exists": false
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/sites",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUnschedListPatient.cs",
+    "formName": "FormUnschedListPatient",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUnschedListSetup.cs",
+    "formName": "FormUnschedListSetup",
+    "endpoints": [
+      {
+        "path": "/api/prefs/UnschedDaysPast",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UnschedDaysFuture",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UnschedDaysPast",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/prefs/UnschedDaysFuture",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdate.cs",
+    "formName": "FormUpdate",
+    "endpoints": [
+      {
+        "path": "/api/updates",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateHistory.cs",
+    "formName": "FormUpdateHistory",
+    "endpoints": [
+      {
+        "path": "/api/updates/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateInProgress.cs",
+    "formName": "FormUpdateInProgress",
+    "endpoints": [
+      {
+        "path": "/api/updates/in-progress",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateInstallMsg.cs",
+    "formName": "FormUpdateInstallMsg",
+    "endpoints": [
+      {
+        "path": "/api/updates/install-message",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUpdateSetup.cs",
+    "formName": "FormUpdateSetup",
+    "endpoints": [
+      {
+        "path": "/api/updates/setup",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserEdit.cs",
+    "formName": "FormUserEdit",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserPassword.cs",
+    "formName": "FormUserPassword",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}/password",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserPrefAdditional.cs",
+    "formName": "FormUserPrefAdditional",
+    "endpoints": [
+      {
+        "path": "/api/users/{id}/preferences",
+        "method": "PATCH",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormUserQuery.cs",
+    "formName": "FormUserQuery",
+    "endpoints": [
+      {
+        "path": "/api/user-queries",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVaccineDefEdit.cs",
+    "formName": "FormVaccineDefEdit",
+    "endpoints": [
+      {
+        "path": "/api/vaccine-defs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVaccineDefSetup.cs",
+    "formName": "FormVaccineDefSetup",
+    "endpoints": [
+      {
+        "path": "/api/vaccine-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/vaccine-defs",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVaccineObsEdit.cs",
+    "formName": "FormVaccineObsEdit",
+    "endpoints": [
+      {
+        "path": "/api/vaccine-observations/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVideo.cs",
+    "formName": "FormVideo",
+    "endpoints": [
+      {
+        "path": "/api/videos/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormVitalsignEdit2014.cs",
+    "formName": "FormVitalsignEdit2014",
+    "endpoints": [
+      {
+        "path": "/api/vital-signs/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebBrowser.cs",
+    "formName": "FormWebBrowser",
+    "endpoints": [
+      {
+        "path": "/api/web-browser",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebBrowserPrefs.cs",
+    "formName": "FormWebBrowserPrefs",
+    "endpoints": [
+      {
+        "path": "/api/web-browser/preferences",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatSession.cs",
+    "formName": "FormWebChatSession",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes/{noteId}",
+        "method": "DELETE",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/end",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients?phone={phone}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatSessionNoteEdit.cs",
+    "formName": "FormWebChatSessionNoteEdit",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions/{id}/notes",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes/{noteId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/sessions/{id}/notes/{noteId}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatSurveys.cs",
+    "formName": "FormWebChatSurveys",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/surveys",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebChatTools.cs",
+    "formName": "FormWebChatTools",
+    "endpoints": [
+      {
+        "path": "/api/webchat/sessions",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/webchat/messages?sessionIds={ids}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/employees",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients?ids={ids}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebFormNextForms.cs",
+    "formName": "FormWebFormNextForms",
+    "endpoints": [
+      {
+        "path": "/api/webforms/next",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebFormSetup.cs",
+    "formName": "FormWebFormSetup",
+    "endpoints": [
+      {
+        "path": "/api/web-forms/preferences",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/web-forms/preferences",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/web-forms/sheet-defs",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebForms.cs",
+    "formName": "FormWebForms",
+    "endpoints": [
+      {
+        "path": "/api/web-forms/forms",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/web-forms/forms/acknowledge",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/web-forms/preferences",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebMailMessageEdit.cs",
+    "formName": "FormWebMailMessageEdit",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/patients/{id}/family-phi",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/email-addresses/notify",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/users?withProviders=true",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/web-mail/messages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/web-mail/messages/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedASAPHistory.cs",
+    "formName": "FormWebSchedASAPHistory",
+    "endpoints": [
+      {
+        "path": "/api/asap-communications/history",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedASAPSend.cs",
+    "formName": "FormWebSchedASAPSend",
+    "endpoints": [
+      {
+        "path": "/api/clinic-prefs/{clinicId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/communications",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/asap-communications",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedAppts.cs",
+    "formName": "FormWebSchedAppts",
+    "endpoints": [
+      {
+        "path": "/api/appointments/web-sched",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/definitions?category=ApptConfirmed",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/providers",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/appointments/{id}",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedCarrierRule.cs",
+    "formName": "FormWebSchedCarrierRule",
+    "endpoints": [
+      {
+        "path": "/api/web-sched-carrier-rules",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedCarrierRuleCopyToClinics.cs",
+    "formName": "FormWebSchedCarrierRuleCopyToClinics",
+    "endpoints": [
+      {
+        "path": "/api/web-sched-carrier-rules/copy",
+        "method": "POST",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebSchedCarrierRuleEdit.cs",
+    "formName": "FormWebSchedCarrierRuleEdit",
+    "endpoints": [
+      {
+        "path": "/api/web-sched-carrier-rules",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWebView.cs",
+    "formName": "FormWebView",
+    "endpoints": [
+      {
+        "path": "/api/webview",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWiki.cs",
+    "formName": "FormWiki",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages/{id}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/user-prefs/{userId}/wiki-homepage",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiAllPages.cs",
+    "formName": "FormWikiAllPages",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiCompare.cs",
+    "formName": "FormWikiCompare",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/revisions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiDrafts.cs",
+    "formName": "FormWikiDrafts",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/drafts",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/drafts/{id}",
+        "method": "DELETE",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiEdit.cs",
+    "formName": "FormWikiEdit",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/pages/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiFileFolder.cs",
+    "formName": "FormWikiFileFolder",
+    "endpoints": [
+      {
+        "path": "/api/wiki/files",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/files",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiHistory.cs",
+    "formName": "FormWikiHistory",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiIncomingLinks.cs",
+    "formName": "FormWikiIncomingLinks",
+    "endpoints": [
+      {
+        "path": "/api/wiki/pages/{title}/incoming-links",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListEdit.cs",
+    "formName": "FormWikiListEdit",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{id}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{id}",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListHeaders.cs",
+    "formName": "FormWikiListHeaders",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{id}/headers",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{id}/headers",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListHistory.cs",
+    "formName": "FormWikiListHistory",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{id}/history",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiListItemEdit.cs",
+    "formName": "FormWikiListItemEdit",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists/{listId}/items/{itemId}",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{listId}/items/{itemId}",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists/{listId}/items",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiLists.cs",
+    "formName": "FormWikiLists",
+    "endpoints": [
+      {
+        "path": "/api/wiki/lists",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/wiki/lists",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormWikiSearch.cs",
+    "formName": "FormWikiSearch",
+    "endpoints": [
+      {
+        "path": "/api/wiki/search",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXChargeReconcile.cs",
+    "formName": "FormXChargeReconcile",
+    "endpoints": [
+      {
+        "path": "/api/xcharge/transactions/import",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXDRSetup.cs",
+    "formName": "FormXDRSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/xdr",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xdr/properties",
+        "method": "PUT",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXWeb.cs",
+    "formName": "FormXWeb",
+    "endpoints": [
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/xweb/transactions",
+        "method": "POST",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXWebTransactions.cs",
+    "formName": "FormXWebTransactions",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/xweb/transactions",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXchargeSetup.cs",
+    "formName": "FormXchargeSetup",
+    "endpoints": [
+      {
+        "path": "/api/clinics",
+        "method": "GET",
+        "exists": true
+      },
+      {
+        "path": "/api/programs/xcharge",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xcharge/properties",
+        "method": "PUT",
+        "exists": false
+      },
+      {
+        "path": "/api/defs/payment-types",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXchargeTokenTool.cs",
+    "formName": "FormXchargeTokenTool",
+    "endpoints": [
+      {
+        "path": "/api/programs/xcharge",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/credit-cards/tokens",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/xcharge/tokens/verify",
+        "method": "POST",
+        "exists": false
+      },
+      {
+        "path": "/api/patients/{id}",
+        "method": "GET",
+        "exists": true
+      }
+    ]
+  },
+  {
+    "formPath": "OpenDental/Forms/FormXchargeTrans.cs",
+    "formName": "FormXchargeTrans",
+    "endpoints": [
+      {
+        "path": "/api/preferences/storecctokens",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xcharge",
+        "method": "GET",
+        "exists": false
+      },
+      {
+        "path": "/api/programs/xcharge/properties",
+        "method": "GET",
+        "exists": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Scaffold 1,555 placeholder endpoints from spec/form-api.json so missing routes exist at compile time
- Remove dynamic registrar and map controllers directly to enable mocking of proposed APIs

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build PractxAPI.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b1a0f0d1e48323aa3a55871f894875